### PR TITLE
remove printing non-execution text blocks in the intermediate script (printing markdown verbatim)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ By default, `numd` provides basic stats on changes made.
 ╭──────────────────┬───────────────────────────────────╮
 │ filename         │ simple_markdown_with_no_output.md │
 │ nushell_blocks   │ 4                                 │
-│ levenshtein_dist │ 41                                │
-│ diff_lines       │ +6 (22.2%)                        │
+│ levenshtein_dist │ 38                                │
+│ diff_lines       │ +9 (37.5%)                        │
 │ diff_words       │ +6 (10.7%)                        │
-│ diff_chars       │ +35 (10.1%)                       │
+│ diff_chars       │ +38 (11%)                         │
 ╰──────────────────┴───────────────────────────────────╯
 ```
 

--- a/README.md
+++ b/README.md
@@ -110,10 +110,12 @@ let path = $nu.temp-path | path join simple_nu_table.md
 "```nushell\n[[a b c]; [1 2 3]]\n```\n" | save -f $path
 
 # let's run this file to see it's outputs
-numd run $path --echo --no-save --no-stats --prepend-code "$env.config.footer_mode = 'never'
+numd run $path --echo --no-save --no-stats --prepend-code "
+    $env.config.footer_mode = 'never'
     $env.config.table.header_on_separator = false
     $env.config.table.index_mode = 'never'
-    $env.config.table.mode = 'basic_compact'"
+    $env.config.table.mode = 'basic_compact'
+"
 ```
 
 Output:

--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ By default, `numd` provides basic stats on changes made.
 > numd run --no-save $path
 ╭──────────────────┬───────────────────────────────────╮
 │ filename         │ simple_markdown_with_no_output.md │
-│ nushell_blocks   │ 3                                 │
-│ levenshtein_dist │ 38                                │
-│ diff_lines       │ +9 (37.5%)                        │
+│ nushell_blocks   │ 4                                 │
+│ levenshtein_dist │ 41                                │
+│ diff_lines       │ +6 (22.2%)                        │
 │ diff_words       │ +6 (10.7%)                        │
-│ diff_chars       │ +38 (11%)                         │
+│ diff_chars       │ +35 (10.1%)                       │
 ╰──────────────────┴───────────────────────────────────╯
 ```
 
@@ -225,7 +225,7 @@ Output:
 ╰──────────────────name───────────────────┴─type─╯
 
 > sys host | get boot_time
-Tue, 29 Oct 2024 18:51:21 -0300 (2 weeks ago)
+Tue, 29 Oct 2024 18:51:25 -0300 (2 weeks ago)
 
 > 2 + 2
 4

--- a/README.md
+++ b/README.md
@@ -243,10 +243,10 @@ Tue, 29 Oct 2024 18:51:25 -0300 (2 weeks ago)
 | numd run $in --echo --no-save
 
 # run examples in the `types_of_data.md` file,
-# save intermed nushell script to `types_of_data.md_intermed.nu`
+# save intermed nushell script to `types_of_data.md_intermed_from_readme.nu`
 [z_examples 3_book_types_of_data types_of_data.md]
 | path join
-| numd run $in --no-backup --intermed-script $'($in)_intermed.nu'
+| numd run $in --no-backup --intermed-script $'($in)_intermed_from_readme.nu'
 ```
 
 ## Development and testing

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -49,7 +49,7 @@ export def match-action [
     match $row_type {
         'text' => {'print-as-it-is'}
         '```output-numd' => {'delete'}
-        $i if 'no-run' in $i => {'print-as-it-is'}
+        $i if ($i =~ 'no-run') => {'print-as-it-is'}
         _ => {'execute'}
     }
 }

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -90,16 +90,14 @@ export def generate-intermediate-script [
     # $md_classified | save $'(date now | into int).json'
 
     $md_classified
-    | group-by block_index
-    | values
     | each {
         let $input = $in
-        let $row_type = $input.row_type.0
+        let $row_type = $input.row_type
         if $row_type != 'text' {
             $env.numd.current_block_options = ($row_type | extract-fence-options)
         }
 
-        $input.line
+        $input.lines
         | if ($row_type == 'text' or
             'no-run' in $env.numd.current_block_options
         ) {

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -10,23 +10,19 @@ export def find-code-blocks []: string -> table {
         }
         | scan --noinit 'text' {|prev_fence curr_fence|
             match $curr_fence {
-                'text' => { if $prev_fence == 'closing-fence' {'text'} else {$prev_fence} }
-                '```' => { if $prev_fence == 'text' {'```'} else {'closing-fence'} }
+                'text' => { if $prev_fence == 'closing-fence' { 'text' } else { $prev_fence } }
+                '```' => { if $prev_fence == 'text' { '```' } else { 'closing-fence' } }
                 _ => { $curr_fence }
             }
         }
         | scan --noinit 'text' {|prev_fence curr_fence|
-            if $curr_fence == 'closing-fence' {$prev_fence} else {$curr_fence}
+            if $curr_fence == 'closing-fence' { $prev_fence } else { $curr_fence }
         }
 
     let $block_index = $row_type
         | window --remainder 2
         | scan 0 {|prev_line curr_line|
-            if $curr_line.0 == $curr_line.1? {
-                $prev_line
-            } else {
-                $prev_line + 1
-            }
+            if $curr_line.0 == $curr_line.1? { $prev_line } else { $prev_line + 1 }
         }
 
     # Wrap lists into columns because the `window` command was used previously

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -146,7 +146,6 @@ export def extract-block-index [
     $nu_res_stdout_lines: list
 ]: nothing -> table {
     let $block_start_line = $nu_res_stdout_lines
-        | prepend '' # in case of code block starting from the first line
         | each {
             if $in =~ $"^(mark-code-block)\\d+$" {
                 split row '-' | last | into int
@@ -157,7 +156,6 @@ export def extract-block-index [
         | scan --noinit (-1) {|prev_index curr_index|
             if $curr_index == -1 {$prev_index} else {$curr_index}
         }
-        | skip # in case of code block starting from the first line
         | wrap block_line
 
     $nu_res_stdout_lines

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -181,7 +181,7 @@ export def merge-markdown [
     $nu_res_with_block_line: table
 ]: nothing -> string {
     $md_classified
-    | where row_type !~ '^(```nu(shell)?(\s(?!.*no-run)|$))|(```output-numd$)'
+    | where row_type !~ '^(```nu(shell)?(\s.*(?!no-run)|$))|(```output-numd$)'
     | append $nu_res_with_block_line
     | sort-by block_line
     | get line

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -322,12 +322,12 @@ export def execute-intermediate-script [
 # Generate a unique identifier for code blocks in markdown to distinguish their output.
 #
 # > mark-code-block 3
-# #code-block-starting-line-in-original-md-3
+# #code-block-marker-3
 export def mark-code-block [
     index?: int
     --end
 ]: nothing -> string {
-    $"#code-block-starting-line-in-original-md-open-($index)"
+    $"#code-block-marker-open-($index)"
     | if $end {
         str replace 'open' 'close'
     } else {}

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -170,6 +170,7 @@ export def merge-markdown [
 ]: nothing -> string {
     $md_classified
     | where row_type !~ '^(```nu(shell)?(\s|$))'
+    | update line {to text}
     | append $nu_res_with_block_index
     | sort-by block_index
     | get line

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -181,7 +181,7 @@ export def merge-markdown [
     $nu_res_with_block_line: table
 ]: nothing -> string {
     $md_classified
-    | where row_type !~ '^(```nu(shell)?(\s|$))|(```output-numd$)'
+    | where row_type !~ '^(```nu(shell)?(\s.*(?!no-run)|$))|(```output-numd$)'
     | append $nu_res_with_block_line
     | sort-by block_line
     | get line

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -153,7 +153,7 @@ export def extract-block-index [
                 -1
             }
         }
-        | scan --noinit 0 {|prev_index curr_index|
+        | scan --noinit (-1) {|prev_index curr_index|
             if $curr_index == -1 {$prev_index} else {$curr_index}
         }
         | wrap block_line

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -146,6 +146,7 @@ export def extract-block-index [
     $nu_res_stdout_lines: list
 ]: nothing -> table {
     let $block_start_line = $nu_res_stdout_lines
+        | prepend '' # in case of code block starting from the first line
         | each {
             if $in =~ $"^(mark-code-block)\\d+$" {
                 split row '-' | last | into int
@@ -156,6 +157,7 @@ export def extract-block-index [
         | scan --noinit (-1) {|prev_index curr_index|
             if $curr_index == -1 {$prev_index} else {$curr_index}
         }
+        | skip # in case of code block starting from the first line
         | wrap block_line
 
     $nu_res_stdout_lines

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -165,6 +165,7 @@ export def extract-block-index [
     | upsert items {
         |i| $i.items.nu_out
         | skip
+        | take until {|x| $x =~ (mark-code-block --end)}
         | str join (char nl)
     }
     | rename block_line line

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -145,7 +145,10 @@ export def execute-block-lines [ ]: list -> list {
 export def extract-block-index [
     $nu_res_stdout_lines: list
 ]: nothing -> table {
-    let $block_start_line = $nu_res_stdout_lines
+    let $clean_lines = $nu_res_stdout_lines
+        | skip until {|x| $x =~ (mark-code-block)}
+
+    let $block_start_line = $clean_lines
         | each {
             if $in =~ $"^(mark-code-block)\\d+$" {
                 split row '-' | last | into int
@@ -158,7 +161,7 @@ export def extract-block-index [
         }
         | wrap block_line
 
-    $nu_res_stdout_lines
+    $clean_lines
     | wrap 'nu_out'
     | merge $block_start_line
     | group-by block_line --to-table

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -486,6 +486,20 @@ export def generate-print-lines []: list -> string {
     | $'($in) | print'
 }
 
+export def generate-tags [
+    $block_number
+    $fence
+]: list -> string {
+    let $input = $in
+    
+    mark-code-block $block_number
+    | append $fence
+    | generate-print-lines
+    | append $input
+    | append '"```" | print'
+    | to text
+}
+
 # Parse options from a code fence and return them as a list.
 #
 # > '```nu no-run, t' | extract-fence-options

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -183,7 +183,7 @@ export def merge-markdown [
     $nu_res_with_block_index: table
 ]: nothing -> string {
     $md_classified
-    | where row_type !~ '^(```nu(shell)?(\s|$))|(```output-numd$)'
+    | where row_type !~ '^(```nu(shell)?(\s|$))'
     | append $nu_res_with_block_index
     | sort-by block_index
     | get line

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -181,7 +181,7 @@ export def merge-markdown [
     $nu_res_with_block_line: table
 ]: nothing -> string {
     $md_classified
-    | where row_type !~ '^(```nu(shell)?(\s.*(?!no-run)|$))|(```output-numd$)'
+    | where row_type !~ '^(```nu(shell)?(\s|$))|(```output-numd$)'
     | append $nu_res_with_block_line
     | sort-by block_line
     | get line

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -181,7 +181,7 @@ export def merge-markdown [
     $nu_res_with_block_line: table
 ]: nothing -> string {
     $md_classified
-    | where row_type !~ '^(```nu(shell)?(\s.*(?!no-run)|$))|(```output-numd$)'
+    | where row_type !~ '^(```nu(shell)?(\s(?!.*no-run)|$))|(```output-numd$)'
     | append $nu_res_with_block_line
     | sort-by block_line
     | get line

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -38,6 +38,11 @@ export def find-code-blocks []: string -> table {
             msg: 'A closing code block fence (```) is missing; the markdown might be invalid.'
         }
     } else {}
+    | group-by block_index --to-table
+    | insert row_type {|i| $i.items.row_type.0}
+    | update items {get line}
+    | rename block_index lines row_type
+    | select block_index row_type lines
 }
 
 # Generate code for execution in the intermediate script within a given code fence.

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -100,7 +100,7 @@ export def generate-intermediate-script [
     # $md_classified | save $'(date now | into int).json'
 
     $md_classified
-    | where row_type != text
+    | where action == 'execute'
     | insert code {|i| $i.line
         | execute-block-lines ($i.row_type | extract-fence-options)
         | generate-tags $i.block_index $i.row_type
@@ -178,7 +178,7 @@ export def merge-markdown [
     $nu_res_with_block_index: table
 ]: nothing -> string {
     $md_classified
-    | where row_type !~ '^(```nu(shell)?(\s|$))'
+    | where action == 'print-block'
     | update line {to text}
     | append $nu_res_with_block_index
     | sort-by block_index
@@ -221,7 +221,7 @@ export def compute-change-stats [
 
     let $nushell_blocks = $new_file_content
         | find-code-blocks
-        | where row_type =~ '^```nu'
+        | where action == 'execute'
         | get block_index
         | uniq
         | length

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -43,6 +43,7 @@ export def find-code-blocks []: string -> table {
     | update items {get line}
     | rename block_index line row_type
     | select block_index row_type line
+    | into int block_index
 }
 
 # Generate code for execution in the intermediate script within a given code fence.

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -40,6 +40,18 @@ export def find-code-blocks []: string -> table {
     | rename block_index line row_type
     | select block_index row_type line
     | into int block_index
+    | insert action {|i| match-action $i.row_type}
+}
+
+export def match-action [
+    $row_type: string
+] {
+    match $row_type {
+        'text' => {'print-block'}
+        '```output-numd' => {'delete'}
+        $i if 'no-run' in $i => {'print-block'}
+        _ => {'execute'}
+    }
 }
 
 # Generate code for execution in the intermediate script within a given code fence.

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -90,7 +90,6 @@ export def generate-intermediate-script [
     # $md_classified | save $'(date now | into int).json'
 
     $md_classified
-    | where row_type != '```output-numd'
     | group-by block_index
     | values
     | each {

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -47,9 +47,9 @@ export def match-action [
     $row_type: string
 ] {
     match $row_type {
-        'text' => {'print-block'}
+        'text' => {'print-as-it-is'}
         '```output-numd' => {'delete'}
-        $i if 'no-run' in $i => {'print-block'}
+        $i if 'no-run' in $i => {'print-as-it-is'}
         _ => {'execute'}
     }
 }
@@ -178,7 +178,7 @@ export def merge-markdown [
     $nu_res_with_block_index: table
 ]: nothing -> string {
     $md_classified
-    | where action == 'print-block'
+    | where action == 'print-as-it-is'
     | update line {to text}
     | append $nu_res_with_block_index
     | sort-by block_index

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -153,7 +153,7 @@ export def extract-block-index [
                 -1
             }
         }
-        | scan --noinit (-1) {|prev_index curr_index|
+        | scan --noinit 0 {|prev_index curr_index|
             if $curr_index == -1 {$prev_index} else {$curr_index}
         }
         | wrap block_line

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -105,6 +105,7 @@ export def generate-intermediate-script [
         } else if $row_type =~ '^```nu(shell)?(\s|$)' {
             execute-block-lines
             | prepend $"\"($row_type)\" | print"
+            | prepend $"\"(mark-code-block $input.block_line.0)\" | print"
             | append $"\"```\" | print"
             | append '' # add an empty line for visual distinction
         }

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -20,14 +20,13 @@ export def find-code-blocks []: string -> table {
         }
 
     let $block_start_line = $row_type
-        | enumerate # enumerate starting index is 0
         | window --remainder 2
-        | scan 1 {|prev_line curr_line|
-            if $curr_line.item.0? == $curr_line.item.1? {
+        | scan 0 {|prev_line curr_line|
+            if $curr_line.0 == $curr_line.1? {
                 $prev_line
             } else {
                 # output the line number with the opening fence of the current block
-                $curr_line.index.0 + 2
+                $prev_line + 1
             }
         }
 

--- a/numd/nu-utils/numd-internals.nu
+++ b/numd/nu-utils/numd-internals.nu
@@ -107,6 +107,7 @@ export def generate-intermediate-script [
             | prepend $"\"($row_type)\" | print"
             | prepend $"\"(mark-code-block $input.block_line.0)\" | print"
             | append $"\"```\" | print"
+            | append $"\"(mark-code-block --end $input.block_line.0)\" | print"
             | append '' # add an empty line for visual distinction
         }
     }
@@ -322,8 +323,12 @@ export def execute-intermediate-script [
 # #code-block-starting-line-in-original-md-3
 export def mark-code-block [
     index?: int
+    --end
 ]: nothing -> string {
-    $"#code-block-starting-line-in-original-md-($index)"
+    $"#code-block-starting-line-in-original-md-open-($index)"
+    | if $end {
+        str replace 'open' 'close'
+    } else {}
 }
 # TODO NUON can be used in mark-code-blocks to set display options
 

--- a/numd/run1.nu
+++ b/numd/run1.nu
@@ -119,6 +119,7 @@ export def clear-outputs [
         | return $in # we return the stripped script here to not spoil original md
     } else {
         merge-markdown $original_md_table $in
+        | clean-markdown
     }
     | if $echo {} else {
         save -f $result_md_path

--- a/numd/run1.nu
+++ b/numd/run1.nu
@@ -37,10 +37,12 @@ export def run [
     | save -f $intermediate_script_path
 
     let $intermed_result = execute-intermediate-script $intermediate_script_path $no_fail_on_error $print_block_results
+        | lines
+        | extract-block-index $in
 
-    $intermed_result | save -f ($file + 'intermed_exec.txt')
+    # $intermed_result | save -f ($file + 'intermed_exec.json')
 
-    let $updated_md_ansi = $intermed_result
+    let $updated_md_ansi = merge-markdown $original_md_table $intermed_result
         | if $in == '' {
             return { filename: $file,
                 comment: "the script didn't produce any output" }

--- a/numd/run1.nu
+++ b/numd/run1.nu
@@ -26,6 +26,8 @@ export def run [
         | toggle-output-fences # should be unnecessary for new files
         | find-code-blocks
 
+    $original_md_table | save -f ($file + '_original_md_table.json')
+
     load-config $config_path --prepend_code $prepend_code --table_width $table_width
 
     let $intermediate_script_path = $intermed_script
@@ -40,7 +42,7 @@ export def run [
         | lines
         | extract-block-index $in
 
-    # $intermed_result | save -f ($file + 'intermed_exec.json')
+    $intermed_result | save -f ($file + '_intermed_exec.json')
 
     let $updated_md_ansi = merge-markdown $original_md_table $intermed_result
         | if $in == '' {

--- a/numd/run1.nu
+++ b/numd/run1.nu
@@ -36,7 +36,11 @@ export def run [
     generate-intermediate-script $original_md_table
     | save -f $intermediate_script_path
 
-    let $updated_md_ansi = execute-intermediate-script $intermediate_script_path $no_fail_on_error $print_block_results
+    let $intermed_result = execute-intermediate-script $intermediate_script_path $no_fail_on_error $print_block_results
+
+    $intermed_result | save -f ($file + 'intermed_exec.txt')
+
+    let $updated_md_ansi = $intermed_result
         | if $in == '' {
             return { filename: $file,
                 comment: "the script didn't produce any output" }

--- a/numd/run1.nu
+++ b/numd/run1.nu
@@ -40,16 +40,16 @@ export def run [
     | save -f $intermediate_script_path
 
     let $intermed_result = execute-intermediate-script $intermediate_script_path $no_fail_on_error $print_block_results
+        | if $in == '' {
+            return { filename: $file,
+                comment: "the script didn't produce any output" }
+        } else {}
         | lines
         | extract-block-index $in
 
     $intermed_result | save -f ($file + '_intermed_exec.json')
 
     let $updated_md_ansi = merge-markdown $original_md_table $intermed_result
-        | if $in == '' {
-            return { filename: $file,
-                comment: "the script didn't produce any output" }
-        } else {}
         | clean-markdown
         | toggle-output-fences --back
 

--- a/numd/run1.nu
+++ b/numd/run1.nu
@@ -25,7 +25,6 @@ export def run [
     let $original_md_table = $original_md
         | toggle-output-fences # should be unnecessary for new files
         | find-code-blocks
-        | where row_type != '```output-numd'
 
     # $original_md_table | save -f ($file + '_original_md_table.json')
 

--- a/numd/run1.nu
+++ b/numd/run1.nu
@@ -27,7 +27,7 @@ export def run [
         | find-code-blocks
         | where row_type != '```output-numd'
 
-    $original_md_table | save -f ($file + '_original_md_table.json')
+    # $original_md_table | save -f ($file + '_original_md_table.json')
 
     load-config $config_path --prepend_code $prepend_code --table_width $table_width
 
@@ -47,7 +47,7 @@ export def run [
         | lines
         | extract-block-index $in
 
-    $nu_res_with_block_index | save -f ($file + '_intermed_exec.json')
+    # $nu_res_with_block_index | save -f ($file + '_intermed_exec.json')
 
     let $updated_md_ansi = merge-markdown $original_md_table $nu_res_with_block_index
         | clean-markdown

--- a/numd/run1.nu
+++ b/numd/run1.nu
@@ -98,7 +98,7 @@ export def clear-outputs [
     | where row_type =~ '^```nu(shell)?(\s|$)'
     | group-by block_index
     | items {|block_index block_lines|
-        $block_lines.line
+        $block_lines.line.0
         | if ($in | where $it =~ '^>' | is-empty) {} else {
             where $it =~ '^(>|#|```)'
         }

--- a/numd/run1.nu
+++ b/numd/run1.nu
@@ -25,6 +25,7 @@ export def run [
     let $original_md_table = $original_md
         | toggle-output-fences # should be unnecessary for new files
         | find-code-blocks
+        | where row_type != '```output-numd'
 
     $original_md_table | save -f ($file + '_original_md_table.json')
 

--- a/numd/run1.nu
+++ b/numd/run1.nu
@@ -39,7 +39,7 @@ export def run [
     generate-intermediate-script $original_md_table
     | save -f $intermediate_script_path
 
-    let $intermed_result = execute-intermediate-script $intermediate_script_path $no_fail_on_error $print_block_results
+    let $nu_res_with_block_index = execute-intermediate-script $intermediate_script_path $no_fail_on_error $print_block_results
         | if $in == '' {
             return { filename: $file,
                 comment: "the script didn't produce any output" }
@@ -47,9 +47,9 @@ export def run [
         | lines
         | extract-block-index $in
 
-    $intermed_result | save -f ($file + '_intermed_exec.json')
+    $nu_res_with_block_index | save -f ($file + '_intermed_exec.json')
 
-    let $updated_md_ansi = merge-markdown $original_md_table $intermed_result
+    let $updated_md_ansi = merge-markdown $original_md_table $nu_res_with_block_index
         | clean-markdown
         | toggle-output-fences --back
 

--- a/numd/run1.nu
+++ b/numd/run1.nu
@@ -95,7 +95,7 @@ export def clear-outputs [
     let $result_md_path = $result_md_path | default $file
 
     $original_md_table
-    | where row_type =~ '^```nu(shell)?(\s|$)'
+    | where action == 'execute'
     | group-by block_index
     | items {|block_index block_lines|
         $block_lines.line.0

--- a/numd/run1.nu
+++ b/numd/run1.nu
@@ -95,7 +95,7 @@ export def clear-outputs [
 
     $original_md_table
     | where row_type =~ '^```nu(shell)?(\s|$)'
-    | group-by block_line
+    | group-by block_index
     | items {|block_index block_lines|
         $block_lines.line
         | if ($in | where $it =~ '^>' | is-empty) {} else {

--- a/quick_test.nu
+++ b/quick_test.nu
@@ -1,0 +1,3 @@
+numd run z_examples/6_edge_cases/simple_markdown_first_block.md
+
+open z_examples/6_edge_cases/simple_markdown_first_block.mdintermed_exec.txt | lines | extract-block-index $in

--- a/quick_test.nu
+++ b/quick_test.nu
@@ -1,3 +1,3 @@
 numd run z_examples/6_edge_cases/simple_markdown_first_block.md
 
-open z_examples/6_edge_cases/simple_markdown_first_block.mdintermed_exec.txt | lines | extract-block-index $in
+# open z_examples/6_edge_cases/simple_markdown_first_block.mdintermed_exec.txt | lines | extract-block-index $in

--- a/quick_test.nu
+++ b/quick_test.nu
@@ -1,3 +1,0 @@
-numd run z_examples/6_edge_cases/simple_markdown_first_block.md
-
-# open z_examples/6_edge_cases/simple_markdown_first_block.mdintermed_exec.txt | lines | extract-block-index $in

--- a/z_examples/1_simple_markdown/simple_markdown.md_intermed.nu
+++ b/z_examples/1_simple_markdown/simple_markdown.md_intermed.nu
@@ -11,13 +11,8 @@ show_empty: false, padding: {left: 1, right: 1},
 trim: {methodology: truncating, wrapping_try_keep_words: false, truncating_suffix: ...},
 header_on_separator: true, abbreviated_row_count: 1000}
 
-"# This is a simple markdown example
-
-## Example 1
-
-the block below will be executed as it is, but won't yield any output
-" | print
-"```nu" | print
+"#code-block-marker-open-1
+```nu" | print
 "let $var1 = 'foo'" | nu-highlight | print
 
 "```\n```output-numd" | print
@@ -26,10 +21,8 @@ let $var1 = 'foo'
 
 "```" | print
 
-"
-## Example 2
-" | print
-"```nu" | print
+"#code-block-marker-open-3
+```nu" | print
 "# This block will produce some output in a separate block
 $var1 | path join 'baz' 'bar'" | nu-highlight | print
 
@@ -40,10 +33,8 @@ $var1 | path join 'baz' 'bar' | table | print; print ''
 
 "```" | print
 
-"
-## Example 3
-" | print
-"```nu" | print
+"#code-block-marker-open-6
+```nu" | print
 "# This block will output results inline" | nu-highlight | print
 
 

--- a/z_examples/2_numd_commands_explanations/numd_commands_explanations.md
+++ b/z_examples/2_numd_commands_explanations/numd_commands_explanations.md
@@ -25,7 +25,7 @@ let $file = $init_numd_pwd_const | path join z_examples 1_simple_markdown simple
 
 let $md_orig = open -r $file | toggle-output-fences
 let $md_orig_table = $md_orig | find-code-blocks
-$md_orig_table
+$md_orig_table | table -e
 ```
 
 Output:

--- a/z_examples/2_numd_commands_explanations/numd_commands_explanations.md
+++ b/z_examples/2_numd_commands_explanations/numd_commands_explanations.md
@@ -31,38 +31,15 @@ $md_orig_table
 Output:
 
 ```
-//  ╭─────────────────────────────────line──────────────────────────────────┬────row_type────┬─block_line─╮
-//  │ # This is a simple markdown example                                   │ text           │          1 │
-//  │                                                                       │ text           │          1 │
-//  │ ## Example 1                                                          │ text           │          1 │
-//  │                                                                       │ text           │          1 │
-//  │ the block below will be executed as it is, but won't yield any output │ text           │          1 │
-//  │                                                                       │ text           │          1 │
-//  │ ```nu                                                                 │ ```nu          │          7 │
-//  │ let $var1 = 'foo'                                                     │ ```nu          │          7 │
-//  │ ```                                                                   │ ```nu          │          7 │
-//  │                                                                       │ text           │         10 │
-//  │ ## Example 2                                                          │ text           │         10 │
-//  │                                                                       │ text           │         10 │
-//  │ ```nu                                                                 │ ```nu          │         13 │
-//  │ # This block will produce some output in a separate block             │ ```nu          │         13 │
-//  │ $var1 | path join 'baz' 'bar'                                         │ ```nu          │         13 │
-//  │ ```                                                                   │ ```nu          │         13 │
-//  │ ```output-numd                                                        │ ```output-numd │         17 │
-//  │ foo/baz/bar                                                           │ ```output-numd │         17 │
-//  │ ```                                                                   │ ```output-numd │         17 │
-//  │                                                                       │ text           │         20 │
-//  │ ## Example 3                                                          │ text           │         20 │
-//  │                                                                       │ text           │         20 │
-//  │ ```nu                                                                 │ ```nu          │         23 │
-//  │ # This block will output results inline                               │ ```nu          │         23 │
-//  │ > whoami                                                              │ ```nu          │         23 │
-//  │ user                                                                  │ ```nu          │         23 │
-//  │                                                                       │ ```nu          │         23 │
-//  │ > 2 + 2                                                               │ ```nu          │         23 │
-//  │ 4                                                                     │ ```nu          │         23 │
-//  │ ```                                                                   │ ```nu          │         23 │
-//  ╰─────────────────────────────────line──────────────────────────────────┴────row_type────┴─block_line─╯
+//  ╭─block_index─┬────row_type────┬──────line──────┬─────action─────╮
+//  │           0 │ text           │ [list 6 items] │ print-as-it-is │
+//  │           1 │ ```nu          │ [list 3 items] │ execute        │
+//  │           2 │ text           │ [list 3 items] │ print-as-it-is │
+//  │           3 │ ```nu          │ [list 4 items] │ execute        │
+//  │           4 │ ```output-numd │ [list 3 items] │ delete         │
+//  │           5 │ text           │ [list 3 items] │ print-as-it-is │
+//  │           6 │ ```nu          │ [list 8 items] │ execute        │
+//  ╰─block_index─┴────row_type────┴──────line──────┴─────action─────╯
 ```
 
 ## generate-intermediate-script
@@ -88,13 +65,8 @@ Output:
 //
 //  const init_numd_pwd_const = '/Users/user/git/numd'
 //
-//  "# This is a simple markdown example
-//
-//  ## Example 1
-//
-//  the block below will be executed as it is, but won't yield any output
-//  " | print
-//  "```nu" | print
+//  "#code-block-marker-open-1
+//  ```nu" | print
 //  "let $var1 = 'foo'" | nu-highlight | print
 //
 //  "```\n```output-numd" | print
@@ -103,10 +75,8 @@ Output:
 //
 //  "```" | print
 //
-//  "
-//  ## Example 2
-//  " | print
-//  "```nu" | print
+//  "#code-block-marker-open-3
+//  ```nu" | print
 //  "# This block will produce some output in a separate block
 //  $var1 | path join 'baz' 'bar'" | nu-highlight | print
 //
@@ -117,10 +87,8 @@ Output:
 //
 //  "```" | print
 //
-//  "
-//  ## Example 3
-//  " | print
-//  "```nu" | print
+//  "#code-block-marker-open-6
+//  ```nu" | print
 //  "# This block will output results inline" | nu-highlight | print
 //
 //
@@ -151,20 +119,13 @@ $nu_res_stdout_lines
 Output:
 
 ```
-//  # This is a simple markdown example
-//
-//  ## Example 1
-//
-//  the block below will be executed as it is, but won't yield any output
-//
+//  #code-block-marker-open-1
 //  ```nu
 //  let $var1 = 'foo'
 //  ```
 //  ```output-numd
 //  ```
-//
-//  ## Example 2
-//
+//  #code-block-marker-open-3
 //  ```nu
 //  # This block will produce some output in a separate block
 //  $var1 | path join 'baz' 'bar'
@@ -173,9 +134,7 @@ Output:
 //  foo/baz/bar
 //
 //  ```
-//
-//  ## Example 3
-//
+//  #code-block-marker-open-6
 //  ```nu
 //  # This block will output results inline
 //  > whoami
@@ -198,18 +157,11 @@ $md_res
 Output:
 
 ```
-//  # This is a simple markdown example
-//
-//  ## Example 1
-//
-//  the block below will be executed as it is, but won't yield any output
-//
+//  #code-block-marker-open-1
 //  ```nu
 //  let $var1 = 'foo'
 //  ```
-//
-//  ## Example 2
-//
+//  #code-block-marker-open-3
 //  ```nu
 //  # This block will produce some output in a separate block
 //  $var1 | path join 'baz' 'bar'
@@ -217,9 +169,7 @@ Output:
 //  ```output-numd
 //  foo/baz/bar
 //  ```
-//
-//  ## Example 3
-//
+//  #code-block-marker-open-6
 //  ```nu
 //  # This block will output results inline
 //  > whoami
@@ -244,9 +194,9 @@ Output:
 //  ╭──────────────────┬────────────────────╮
 //  │ filename         │ simple_markdown.md │
 //  │ nushell_blocks   │ 3                  │
-//  │ levenshtein_dist │ 0                  │
-//  │ diff_lines       │ 0%                 │
-//  │ diff_words       │ 0%                 │
-//  │ diff_chars       │ 0%                 │
+//  │ levenshtein_dist │ 155                │
+//  │ diff_lines       │ -9 (-30%)          │
+//  │ diff_words       │ -11 (-17.5%)       │
+//  │ diff_chars       │ -74 (-19.3%)       │
 //  ╰──────────────────┴────────────────────╯
 ```

--- a/z_examples/2_numd_commands_explanations/numd_commands_explanations.md
+++ b/z_examples/2_numd_commands_explanations/numd_commands_explanations.md
@@ -31,15 +31,52 @@ $md_orig_table | table -e
 Output:
 
 ```
-//  ╭─block_index─┬────row_type────┬──────line──────┬─────action─────╮
-//  │           0 │ text           │ [list 6 items] │ print-as-it-is │
-//  │           1 │ ```nu          │ [list 3 items] │ execute        │
-//  │           2 │ text           │ [list 3 items] │ print-as-it-is │
-//  │           3 │ ```nu          │ [list 4 items] │ execute        │
-//  │           4 │ ```output-numd │ [list 3 items] │ delete         │
-//  │           5 │ text           │ [list 3 items] │ print-as-it-is │
-//  │           6 │ ```nu          │ [list 8 items] │ execute        │
-//  ╰─block_index─┴────row_type────┴──────line──────┴─────action─────╯
+//  ╭─block_index──┬────row_type─────┬────────────────────────────────────line────────────────────────────────────┬─────action──────╮
+//  │            0 │ text            │ ╭───────────────────────────────────────────────────────────────────────╮  │ print-as-it-is  │
+//  │              │                 │ │ # This is a simple markdown example                                   │  │                 │
+//  │              │                 │ │                                                                       │  │                 │
+//  │              │                 │ │ ## Example 1                                                          │  │                 │
+//  │              │                 │ │                                                                       │  │                 │
+//  │              │                 │ │ the block below will be executed as it is, but won't yield any output │  │                 │
+//  │              │                 │ │                                                                       │  │                 │
+//  │              │                 │ ╰───────────────────────────────────────────────────────────────────────╯  │                 │
+//  │            1 │ ```nu           │ ╭───────────────────╮                                                      │ execute         │
+//  │              │                 │ │ ```nu             │                                                      │                 │
+//  │              │                 │ │ let $var1 = 'foo' │                                                      │                 │
+//  │              │                 │ │ ```               │                                                      │                 │
+//  │              │                 │ ╰───────────────────╯                                                      │                 │
+//  │            2 │ text            │ ╭──────────────╮                                                           │ print-as-it-is  │
+//  │              │                 │ │              │                                                           │                 │
+//  │              │                 │ │ ## Example 2 │                                                           │                 │
+//  │              │                 │ │              │                                                           │                 │
+//  │              │                 │ ╰──────────────╯                                                           │                 │
+//  │            3 │ ```nu           │ ╭───────────────────────────────────────────────────────────╮              │ execute         │
+//  │              │                 │ │ ```nu                                                     │              │                 │
+//  │              │                 │ │ # This block will produce some output in a separate block │              │                 │
+//  │              │                 │ │ $var1 | path join 'baz' 'bar'                             │              │                 │
+//  │              │                 │ │ ```                                                       │              │                 │
+//  │              │                 │ ╰───────────────────────────────────────────────────────────╯              │                 │
+//  │            4 │ ```output-numd  │ ╭────────────────╮                                                         │ delete          │
+//  │              │                 │ │ ```output-numd │                                                         │                 │
+//  │              │                 │ │ foo/baz/bar    │                                                         │                 │
+//  │              │                 │ │ ```            │                                                         │                 │
+//  │              │                 │ ╰────────────────╯                                                         │                 │
+//  │            5 │ text            │ ╭──────────────╮                                                           │ print-as-it-is  │
+//  │              │                 │ │              │                                                           │                 │
+//  │              │                 │ │ ## Example 3 │                                                           │                 │
+//  │              │                 │ │              │                                                           │                 │
+//  │              │                 │ ╰──────────────╯                                                           │                 │
+//  │            6 │ ```nu           │ ╭─────────────────────────────────────────╮                                │ execute         │
+//  │              │                 │ │ ```nu                                   │                                │                 │
+//  │              │                 │ │ # This block will output results inline │                                │                 │
+//  │              │                 │ │ > whoami                                │                                │                 │
+//  │              │                 │ │ user                                    │                                │                 │
+//  │              │                 │ │                                         │                                │                 │
+//  │              │                 │ │ > 2 + 2                                 │                                │                 │
+//  │              │                 │ │ 4                                       │                                │                 │
+//  │              │                 │ │ ```                                     │                                │                 │
+//  │              │                 │ ╰─────────────────────────────────────────╯                                │                 │
+//  ╰─block_index──┴────row_type─────┴────────────────────────────────────line────────────────────────────────────┴─────action──────╯
 ```
 
 ## generate-intermediate-script

--- a/z_examples/2_numd_commands_explanations/numd_commands_explanations.md_intermed.nu
+++ b/z_examples/2_numd_commands_explanations/numd_commands_explanations.md_intermed.nu
@@ -42,7 +42,7 @@ let $file = $init_numd_pwd_const | path join z_examples 1_simple_markdown simple
 
 let $md_orig = open -r $file | toggle-output-fences
 let $md_orig_table = $md_orig | find-code-blocks
-$md_orig_table" | nu-highlight | print
+$md_orig_table | table -e" | nu-highlight | print
 
 "```\n```output-numd" | print
 
@@ -51,7 +51,7 @@ let $file = $init_numd_pwd_const | path join z_examples 1_simple_markdown simple
 
 let $md_orig = open -r $file | toggle-output-fences
 let $md_orig_table = $md_orig | find-code-blocks
-$md_orig_table | table | lines | each {$'//  ($in)' | str trim --right} | str join (char nl) | table | print; print ''
+$md_orig_table | table -e | table | lines | each {$'//  ($in)' | str trim --right} | str join (char nl) | table | print; print ''
 
 "```" | print
 

--- a/z_examples/2_numd_commands_explanations/numd_commands_explanations.md_intermed.nu
+++ b/z_examples/2_numd_commands_explanations/numd_commands_explanations.md_intermed.nu
@@ -11,11 +11,8 @@ show_empty: false, padding: {left: 1, right: 1},
 trim: {methodology: truncating, wrapping_try_keep_words: false, truncating_suffix: ...},
 header_on_separator: true, abbreviated_row_count: 1000}
 
-"# numd commands explanation
-
-In the code block below, we set settings and variables for executing this entire document.
-" | print
-"```nu" | print
+"#code-block-marker-open-1
+```nu" | print
 "# This setting is for overriding the author's usual small number of `abbreviated_row_count`.
 $env.config.table.abbreviated_row_count = 100
 
@@ -38,14 +35,8 @@ use ($init_numd_pwd_const | path join numd nu-utils numd-internals.nu) *
 
 "```" | print
 
-"
-## numd-internals.nu
-
-### find-code-blocks
-
-This command is used for parsing initial markdown to detect executable code blocks.
-" | print
-"```nu indent-output" | print
+"#code-block-marker-open-3
+```nu indent-output" | print
 "# Here we set the `$file` variable (which will be used in several commands throughout this script) to point to `z_examples/1_simple_markdown/simple_markdown.md`.
 let $file = $init_numd_pwd_const | path join z_examples 1_simple_markdown simple_markdown.md
 
@@ -64,12 +55,8 @@ $md_orig_table | table | lines | each {$'//  ($in)' | str trim --right} | str jo
 
 "```" | print
 
-"
-## generate-intermediate-script
-
-The `generate-intermediate-script` command generates a script that contains code from all executable blocks and `numd` service commands used for capturing outputs.
-" | print
-"```nu indent-output" | print
+"#code-block-marker-open-6
+```nu indent-output" | print
 "# Here we emulate that the `$intermed_script_path` options is not set
 let $intermed_script_path = $file
     | modify-path --prefix $'numd-temp-(generate-timestamp)' --suffix '.nu'
@@ -92,12 +79,8 @@ open $intermed_script_path | table | lines | each {$'//  ($in)' | str trim --rig
 
 "```" | print
 
-"
-## execute-intermediate-script
-
-The `execute-intermediate-script` command runs and captures outputs of the executed intermediate script.
-" | print
-"```nu indent-output" | print
+"#code-block-marker-open-9
+```nu indent-output" | print
 "# the flag `$no_fail_on_error` is set to false
 let $no_fail_on_error = false
 
@@ -116,8 +99,8 @@ $nu_res_stdout_lines | table | lines | each {$'//  ($in)' | str trim --right} | 
 
 "```" | print
 
-"" | print
-"```nu indent-output" | print
+"#code-block-marker-open-12
+```nu indent-output" | print
 "let $md_res = $nu_res_stdout_lines
     | str join (char nl)
     | clean-markdown
@@ -134,12 +117,8 @@ $md_res | table | lines | each {$'//  ($in)' | str trim --right} | str join (cha
 
 "```" | print
 
-"
-## compute-change-stats
-
-The `compute-change-stats` command displays stats on the changes made.
-" | print
-"```nu indent-output" | print
+"#code-block-marker-open-15
+```nu indent-output" | print
 "compute-change-stats $file $md_orig $md_res" | nu-highlight | print
 
 "```\n```output-numd" | print

--- a/z_examples/3_book_types_of_data/types_of_data.md
+++ b/z_examples/3_book_types_of_data/types_of_data.md
@@ -255,10 +255,10 @@ You can iterate over records by first transposing it into a table:
 
 ```nushell
 > {name: sam, rank: 10} | transpose key value
-╭─key──┬─value─╮
-│ name │ sam   │
-│ rank │    10 │
-╰─key──┴─value─╯
+╭─#─┬─key──┬─value─╮
+│ 0 │ name │ sam   │
+│ 1 │ rank │    10 │
+╰─#─┴─key──┴─value─╯
 ```
 
 Accessing records' data is done by placing a `.` before a string, which is usually a bare string:
@@ -293,11 +293,11 @@ Lists are ordered sequences of data values. List syntax is very similar to array
 
 ```nushell
 > [sam fred george]
-╭────────╮
-│ sam    │
-│ fred   │
-│ george │
-╰────────╯
+╭───┬────────╮
+│ 0 │ sam    │
+│ 1 │ fred   │
+│ 2 │ george │
+╰───┴────────╯
 ```
 
 :::tip
@@ -305,10 +305,10 @@ Lists are equivalent to the individual columns of tables. You can think of a lis
 
 ```nushell
 > [bell book candle] | where ($it =~ 'b')
-╭──────╮
-│ bell │
-│ book │
-╰──────╯
+╭───┬──────╮
+│ 0 │ bell │
+│ 1 │ book │
+╰───┴──────╯
 ```
 
 :::
@@ -324,11 +324,11 @@ To get a sub-list from a list, you can use the [`range`](/commands/docs/range.md
 
 ```nushell
 > [a b c d e f] | range 1..3
-╭───╮
-│ b │
-│ c │
-│ d │
-╰───╯
+╭───┬───╮
+│ 0 │ b │
+│ 1 │ c │
+│ 2 │ d │
+╰───┴───╯
 ```
 
 To append one or more lists together, optionally with values interspersed in between, you can use the
@@ -337,13 +337,13 @@ To append one or more lists together, optionally with values interspersed in bet
 ```nushell
 > let x = [1 2]
 > [...$x 3 ...(4..7 | take 2)]
-╭───╮
-│ 1 │
-│ 2 │
-│ 3 │
-│ 4 │
-│ 5 │
-╰───╯
+╭───┬───╮
+│ 0 │ 1 │
+│ 1 │ 2 │
+│ 2 │ 3 │
+│ 3 │ 4 │
+│ 4 │ 5 │
+╰───┴───╯
 ```
 
 ## Tables
@@ -354,20 +354,20 @@ We can create our own tables similarly to how we create a list. Because tables a
 
 ```nushell
 > [[column1, column2]; [Value1, Value2] [Value3, Value4]]
-╭─column1─┬─column2─╮
-│ Value1  │ Value2  │
-│ Value3  │ Value4  │
-╰─column1─┴─column2─╯
+╭─#─┬─column1─┬─column2─╮
+│ 0 │ Value1  │ Value2  │
+│ 1 │ Value3  │ Value4  │
+╰─#─┴─column1─┴─column2─╯
 ```
 
 You can also create a table as a list of records, JSON-style:
 
 ```nushell
 > [{name: sam, rank: 10}, {name: bob, rank: 7}]
-╭─name─┬─rank─╮
-│ sam  │   10 │
-│ bob  │    7 │
-╰─name─┴─rank─╯
+╭─#─┬─name─┬─rank─╮
+│ 0 │ sam  │   10 │
+│ 1 │ bob  │    7 │
+╰─#─┴─name─┴─rank─╯
 ```
 
 :::tip
@@ -405,32 +405,32 @@ Moreover, you can also access entire columns of a table by name, to obtain lists
 
 ```nushell
 > [{x:12 y:5} {x:4 y:7} {x:2 y:2}].x
-╭────╮
-│ 12 │
-│  4 │
-│  2 │
-╰────╯
+╭───┬────╮
+│ 0 │ 12 │
+│ 1 │  4 │
+│ 2 │  2 │
+╰───┴────╯
 ```
 
 Of course, these resulting lists don't have the column names of the table. To remove columns from a table while leaving it as a table, you'll commonly use the [`select`](/commands/docs/select.md) command with column names:
 
 ```nushell
 > [{x:0 y:5 z:1} {x:4 y:7 z:3} {x:2 y:2 z:0}] | select y z
-╭─y─┬─z─╮
-│ 5 │ 1 │
-│ 7 │ 3 │
-│ 2 │ 0 │
-╰─y─┴─z─╯
+╭─#─┬─y─┬─z─╮
+│ 0 │ 5 │ 1 │
+│ 1 │ 7 │ 3 │
+│ 2 │ 2 │ 0 │
+╰─#─┴─y─┴─z─╯
 ```
 
 To remove rows from a table, you'll commonly use the [`select`](/commands/docs/select.md) command with row numbers, as you would with a list:
 
 ```nushell
 > [{x:0 y:5 z:1} {x:4 y:7 z:3} {x:2 y:2 z:0}] | select 1 2
-╭─x─┬─y─┬─z─╮
-│ 4 │ 7 │ 3 │
-│ 2 │ 2 │ 0 │
-╰─x─┴─y─┴─z─╯
+╭─#─┬─x─┬─y─┬─z─╮
+│ 0 │ 4 │ 7 │ 3 │
+│ 1 │ 2 │ 2 │ 0 │
+╰─#─┴─x─┴─y─┴─z─╯
 ```
 
 #### Optional cell paths
@@ -439,10 +439,10 @@ By default, cell path access will fail if it can't access the requested row or c
 
 ```nushell
 > [{foo: 123}, {}].foo?
-╭─────╮
-│ 123 │
-│     │
-╰─────╯
+╭───┬─────╮
+│ 0 │ 123 │
+│ 1 │     │
+╰───┴─────╯
 ```
 
 When using optional cell path members, missing data is replaced with `null`.

--- a/z_examples/3_book_types_of_data/types_of_data.md
+++ b/z_examples/3_book_types_of_data/types_of_data.md
@@ -255,10 +255,10 @@ You can iterate over records by first transposing it into a table:
 
 ```nushell
 > {name: sam, rank: 10} | transpose key value
-╭─#─┬─key──┬─value─╮
-│ 0 │ name │ sam   │
-│ 1 │ rank │    10 │
-╰─#─┴─key──┴─value─╯
+╭─key──┬─value─╮
+│ name │ sam   │
+│ rank │    10 │
+╰─key──┴─value─╯
 ```
 
 Accessing records' data is done by placing a `.` before a string, which is usually a bare string:
@@ -293,11 +293,11 @@ Lists are ordered sequences of data values. List syntax is very similar to array
 
 ```nushell
 > [sam fred george]
-╭───┬────────╮
-│ 0 │ sam    │
-│ 1 │ fred   │
-│ 2 │ george │
-╰───┴────────╯
+╭────────╮
+│ sam    │
+│ fred   │
+│ george │
+╰────────╯
 ```
 
 :::tip
@@ -305,10 +305,10 @@ Lists are equivalent to the individual columns of tables. You can think of a lis
 
 ```nushell
 > [bell book candle] | where ($it =~ 'b')
-╭───┬──────╮
-│ 0 │ bell │
-│ 1 │ book │
-╰───┴──────╯
+╭──────╮
+│ bell │
+│ book │
+╰──────╯
 ```
 
 :::
@@ -324,11 +324,11 @@ To get a sub-list from a list, you can use the [`range`](/commands/docs/range.md
 
 ```nushell
 > [a b c d e f] | range 1..3
-╭───┬───╮
-│ 0 │ b │
-│ 1 │ c │
-│ 2 │ d │
-╰───┴───╯
+╭───╮
+│ b │
+│ c │
+│ d │
+╰───╯
 ```
 
 To append one or more lists together, optionally with values interspersed in between, you can use the
@@ -337,13 +337,13 @@ To append one or more lists together, optionally with values interspersed in bet
 ```nushell
 > let x = [1 2]
 > [...$x 3 ...(4..7 | take 2)]
-╭───┬───╮
-│ 0 │ 1 │
-│ 1 │ 2 │
-│ 2 │ 3 │
-│ 3 │ 4 │
-│ 4 │ 5 │
-╰───┴───╯
+╭───╮
+│ 1 │
+│ 2 │
+│ 3 │
+│ 4 │
+│ 5 │
+╰───╯
 ```
 
 ## Tables
@@ -354,20 +354,20 @@ We can create our own tables similarly to how we create a list. Because tables a
 
 ```nushell
 > [[column1, column2]; [Value1, Value2] [Value3, Value4]]
-╭─#─┬─column1─┬─column2─╮
-│ 0 │ Value1  │ Value2  │
-│ 1 │ Value3  │ Value4  │
-╰─#─┴─column1─┴─column2─╯
+╭─column1─┬─column2─╮
+│ Value1  │ Value2  │
+│ Value3  │ Value4  │
+╰─column1─┴─column2─╯
 ```
 
 You can also create a table as a list of records, JSON-style:
 
 ```nushell
 > [{name: sam, rank: 10}, {name: bob, rank: 7}]
-╭─#─┬─name─┬─rank─╮
-│ 0 │ sam  │   10 │
-│ 1 │ bob  │    7 │
-╰─#─┴─name─┴─rank─╯
+╭─name─┬─rank─╮
+│ sam  │   10 │
+│ bob  │    7 │
+╰─name─┴─rank─╯
 ```
 
 :::tip
@@ -405,32 +405,32 @@ Moreover, you can also access entire columns of a table by name, to obtain lists
 
 ```nushell
 > [{x:12 y:5} {x:4 y:7} {x:2 y:2}].x
-╭───┬────╮
-│ 0 │ 12 │
-│ 1 │  4 │
-│ 2 │  2 │
-╰───┴────╯
+╭────╮
+│ 12 │
+│  4 │
+│  2 │
+╰────╯
 ```
 
 Of course, these resulting lists don't have the column names of the table. To remove columns from a table while leaving it as a table, you'll commonly use the [`select`](/commands/docs/select.md) command with column names:
 
 ```nushell
 > [{x:0 y:5 z:1} {x:4 y:7 z:3} {x:2 y:2 z:0}] | select y z
-╭─#─┬─y─┬─z─╮
-│ 0 │ 5 │ 1 │
-│ 1 │ 7 │ 3 │
-│ 2 │ 2 │ 0 │
-╰─#─┴─y─┴─z─╯
+╭─y─┬─z─╮
+│ 5 │ 1 │
+│ 7 │ 3 │
+│ 2 │ 0 │
+╰─y─┴─z─╯
 ```
 
 To remove rows from a table, you'll commonly use the [`select`](/commands/docs/select.md) command with row numbers, as you would with a list:
 
 ```nushell
 > [{x:0 y:5 z:1} {x:4 y:7 z:3} {x:2 y:2 z:0}] | select 1 2
-╭─#─┬─x─┬─y─┬─z─╮
-│ 0 │ 4 │ 7 │ 3 │
-│ 1 │ 2 │ 2 │ 0 │
-╰─#─┴─x─┴─y─┴─z─╯
+╭─x─┬─y─┬─z─╮
+│ 4 │ 7 │ 3 │
+│ 2 │ 2 │ 0 │
+╰─x─┴─y─┴─z─╯
 ```
 
 #### Optional cell paths
@@ -439,10 +439,10 @@ By default, cell path access will fail if it can't access the requested row or c
 
 ```nushell
 > [{foo: 123}, {}].foo?
-╭───┬─────╮
-│ 0 │ 123 │
-│ 1 │     │
-╰───┴─────╯
+╭─────╮
+│ 123 │
+│     │
+╰─────╯
 ```
 
 When using optional cell path members, missing data is replaced with `null`.

--- a/z_examples/3_book_types_of_data/types_of_data.md_intermed.nu
+++ b/z_examples/3_book_types_of_data/types_of_data.md_intermed.nu
@@ -3,92 +3,40 @@
 
 const init_numd_pwd_const = '/Users/user/git/numd'
 
-"# Types of Data
+# numd config loaded from `/Users/user/git/numd/numd_config_example1.yaml`
 
-Traditionally, Unix shell commands have communicated with each other using strings of text: one command would write text to standard output (often abbreviated 'stdout') and the other would read text from standard input (or 'stdin'), allowing the two commands to communicate.
+$env.config.footer_mode = 'always';
+$env.config.table = {mode: rounded, index_mode: never,
+show_empty: false, padding: {left: 1, right: 1},
+trim: {methodology: truncating, wrapping_try_keep_words: false, truncating_suffix: ...},
+header_on_separator: true, abbreviated_row_count: 1000}
 
-Nu embraces this approach, and expands it to include other types of data, in addition to strings.
-
-Like many programming languages, Nu models data using a set of simple, and structured data types. Simple data types include integers, floats, strings, booleans, dates. There are also special types for filesizes and time durations.
-
-The [`describe`](/commands/docs/describe.md) command returns the type of a data value:
-" | print
-"```nushell" | print
+"#code-block-marker-open-1
+```nushell" | print
 "> 42 | describe" | nu-highlight | print
 
 42 | describe | table | print; print ''
 
 "```" | print
 
-"
-## Types at a glance
-
-| Type              | Example                                                               |
-| ----------------- | --------------------------------------------------------------------- |
-| Integers          | `-65535`                                                              |
-| Decimals (floats) | `9.9999`, `Infinity`                                                  |
-| Strings           | <code>\"hole 18\", 'hole 18', \\`hole 18\\`, hole18</code>                |
-| Booleans          | `true`                                                                |
-| Dates             | `2000-01-01`                                                          |
-| Durations         | `2min + 12sec`                                                        |
-| File sizes        | `64mb`                                                                |
-| Ranges            | `0..4`, `0..<5`, `0..`, `..4`                                         |
-| Binary            | `0x[FE FF]`                                                           |
-| Lists             | `[0 1 'two' 3]`                                                       |
-| Records           | `{name:\"Nushell\", lang: \"Rust\"}`                                      |
-| Tables            | `[{x:12, y:15}, {x:8, y:9}]`, `[[x, y]; [12, 15], [8, 9]]`            |
-| Closures          | `{\\|e\\| $e + 1 \\| into string }`, `{ $in.name.0 \\| path exists }`     |
-| Blocks            | `if true { print \"hello!\" }`, `loop { print \"press ctrl-c to exit\" }` |
-| Null              | `null`                                                                |
-
-## Integers
-
-Examples of integers (i.e. \"round numbers\") include 1, 0, -5, and 100.
-You can parse a string into an integer with the [`into int`](/commands/docs/into_int.md) command
-" | print
-"```nushell" | print
+"#code-block-marker-open-3
+```nushell" | print
 "> \"-5\" | into int" | nu-highlight | print
 
 "-5" | into int | table | print; print ''
 
 "```" | print
 
-"
-## Decimals (floats)
-
-Decimal numbers are numbers with some fractional component. Examples include 1.5, 2.0, and 15.333.
-You can cast a string into a Float with the [`into float`](/commands/docs/into_float.md) command
-" | print
-"```nushell" | print
+"#code-block-marker-open-5
+```nushell" | print
 "> \"1.2\" | into float" | nu-highlight | print
 
 "1.2" | into float | table | print; print ''
 
 "```" | print
 
-"
-## Strings
-
-A string of characters that represents text. There are a few ways these can be constructed:
-
-- Double quotes
-  - `\"Line1\\nLine2\\n\"`
-- Single quotes
-  `'She said \"Nushell is the future\".'`
-- Dynamic string interpolation
-  - `$\"6 x 7 = (6 * 7)\"`
-  - `ls | each { |it| $\"($it.name) is ($it.size)\" }`
-- Bare strings
-  - `print hello`
-  - `[foo bar baz]`
-
-See [Working with strings](working_with_strings.md) and [Handling Strings](https://www.nushell.sh/book/loading_data.html#handling-strings) for details.
-
-## Booleans
-
-There are just two boolean values: `true` and `false`. Rather than writing the values directly, they often result from a comparison:
-" | print
-"```nushell" | print
+"#code-block-marker-open-7
+```nushell" | print
 "> let mybool = 2 > 1" | nu-highlight | print
 
 let mybool = 2 > 1
@@ -107,78 +55,24 @@ $mybool | table | print; print ''
 
 "```" | print
 
-"
-## Dates
-
-Dates and times are held together in the Date value type. Date values used by the system are timezone-aware, and by default use the UTC timezone.
-
-Dates are in three forms, based on the RFC 3339 standard:
-
-- A date:
-  - `2022-02-02`
-- A date and time (in GMT):
-  - `2022-02-02T14:30:00`
-- A date and time with timezone:
-  - `2022-02-02T14:30:00+05:00`
-
-## Durations
-
-Durations represent a length of time. This chart shows all durations currently supported:
-
-| Duration | Length          |
-| -------- | --------------- |
-| `1ns`    | one nanosecond  |
-| `1us`    | one microsecond |
-| `1ms`    | one millisecond |
-| `1sec`   | one second      |
-| `1min`   | one minute      |
-| `1hr`    | one hour        |
-| `1day`   | one day         |
-| `1wk`    | one week        |
-
-You can make fractional durations:
-" | print
-"```nushell" | print
+"#code-block-marker-open-9
+```nushell" | print
 "> 3.14day" | nu-highlight | print
 
 3.14day | table | print; print ''
 
 "```" | print
 
-"
-And you can do calculations with durations:
-" | print
-"```nushell" | print
+"#code-block-marker-open-11
+```nushell" | print
 "> 30day / 1sec  # How many seconds in 30 days?" | nu-highlight | print
 
 30day / 1sec | table | print; print ''
 
 "```" | print
 
-"
-## File sizes
-
-Nushell also has a special type for file sizes. Examples include `100b`, `15kb`, and `100mb`.
-
-The full list of filesize units are:
-
-- `b`: bytes
-- `kb`: kilobytes (aka 1000 bytes)
-- `mb`: megabytes
-- `gb`: gigabytes
-- `tb`: terabytes
-- `pb`: petabytes
-- `eb`: exabytes
-- `kib`: kibibytes (aka 1024 bytes)
-- `mib`: mebibytes
-- `gib`: gibibytes
-- `tib`: tebibytes
-- `pib`: pebibytes
-- `eib`: exbibytes
-
-As with durations, you can make fractional file sizes, and do calculations:
-" | print
-"```nushell" | print
+"#code-block-marker-open-13
+```nushell" | print
 "> 1Gb / 1b" | nu-highlight | print
 
 1Gb / 1b | table | print; print ''
@@ -193,50 +87,8 @@ As with durations, you can make fractional file sizes, and do calculations:
 
 "```" | print
 
-"
-## Ranges
-
-A range is a way of expressing a sequence of integer or float values from start to finish. They take the form \\<start\\>..\\<end\\>. For example, the range `1..3` means the numbers 1, 2, and 3.
-
-::: tip
-
-You can also easily create lists of characters with a form similar to ranges with the command [`seq char`](/commands/docs/seq_char.html) as well as with dates using the [`seq date`](/commands/docs/seq_date.html) command.
-
-:::
-
-### Specifying the step
-
-You can specify the step of a range with the form \\<start\\>..\\<second\\>..\\<end\\>, where the step between values in the range is the distance between the \\<start\\> and \\<second\\> values, which numerically is \\<second\\> - \\<start\\>. For example, the range `2..5..11` means the numbers 2, 5, 8, and 11 because the step is \\<second\\> - \\<first\\> = 5 - 2 = 3. The third value is 5 + 3 = 8 and the fourth value is 8 + 3 = 11.
-
-[`seq`](/commands/docs/seq.md) can also create sequences of numbers, and provides an alternate way of specifying the step with three parameters. It's called with `seq $start $step $end` where the step amount is the second parameter rather than being the second parameter minus the first parameter. So `2..5..9` would be equivalent to `seq 2 3 9`.
-
-### Inclusive and non-inclusive ranges
-
-Ranges are inclusive by default, meaning that the ending value is counted as part of the range. The range `1..3` includes the number `3` as the last value in the range.
-
-Sometimes, you may want a range that is limited by a number but doesn't use that number in the output. For this, you can use `..<` instead of `..`. For example, `1..<5` is the numbers 1, 2, 3, and 4.
-
-### Open-ended ranges
-
-Ranges can also be open-ended. You can remove the start or the end of the range to make it open-ended.
-
-Let's say you wanted to start counting at 3, but you didn't have a specific end in mind. You could use the range `3..` to represent this. When you use a range that's open-ended on the right side, remember that this will continue counting for as long as possible, which could be a very long time! You'll often want to use open-ended ranges with commands like [`take`](/commands/docs/take.md), so you can take the number of elements you want from the range.
-
-You can also make the start of the range open. In this case, Nushell will start counting with `0`. For example, the range `..2` is the numbers 0, 1, and 2.
-
-::: warning
-
-Watch out for displaying open-ended ranges like just entering `3..` into the command line. It will keep printing out numbers very quickly until you stop it with something like Ctr + c.
-
-:::
-
-## Binary data
-
-Binary data, like the data from an image file, is a group of raw bytes.
-
-You can write binary as a literal using any of the `0x[...]`, `0b[...]`, or `0o[...]` forms:
-" | print
-"```nushell" | print
+"#code-block-marker-open-15
+```nushell" | print
 "> 0x[1F FF]  # Hexadecimal" | nu-highlight | print
 
 0x[1F FF] | table | print; print ''
@@ -251,75 +103,48 @@ You can write binary as a literal using any of the `0x[...]`, `0b[...]`, or `0o[
 
 "```" | print
 
-"
-Incomplete bytes will be left-padded with zeros.
-
-## Structured data
-
-Structured data builds from the simple data. For example, instead of a single integer, structured data gives us a way to represent multiple integers in the same value. Here's a list of the currently supported structured data types: records, lists and tables.
-
-## Records
-
-Records hold key-value pairs, which associate string keys with various data values. Record syntax is very similar to objects in JSON. However, commas are _not_ required to separate values if Nushell can easily distinguish them!
-" | print
-"```nushell" | print
+"#code-block-marker-open-17
+```nushell" | print
 "> {name: sam rank: 10}" | nu-highlight | print
 
 {name: sam rank: 10} | table | print; print ''
 
 "```" | print
 
-"
-As these can sometimes have many fields, a record is printed up-down rather than left-right.
-
-:::tip
-A record is identical to a single row of a table (see below). You can think of a record as essentially being a \"one-row table\", with each of its keys as a column (although a true one-row table is something distinct from a record).
-
-This means that any command that operates on a table's rows _also_ operates on records. For instance, [`insert`](/commands/docs/insert.md), which adds data to each of a table's rows, can be used with records:
-" | print
-"```nushell" | print
+"#code-block-marker-open-19
+```nushell" | print
 "> {x:3 y:1} | insert z 0" | nu-highlight | print
 
 {x:3 y:1} | insert z 0 | table | print; print ''
 
 "```" | print
 
-"
-:::
-
-You can iterate over records by first transposing it into a table:
-" | print
-"```nushell" | print
+"#code-block-marker-open-21
+```nushell" | print
 "> {name: sam, rank: 10} | transpose key value" | nu-highlight | print
 
 {name: sam, rank: 10} | transpose key value | table | print; print ''
 
 "```" | print
 
-"
-Accessing records' data is done by placing a `.` before a string, which is usually a bare string:
-" | print
-"```nushell" | print
+"#code-block-marker-open-23
+```nushell" | print
 "> {x:12 y:4}.x" | nu-highlight | print
 
 {x:12 y:4}.x | table | print; print ''
 
 "```" | print
 
-"
-However, if a record has a key name that can't be expressed as a bare string, or resembles an integer (see lists, below), you'll need to use more explicit string syntax, like so:
-" | print
-"```nushell" | print
+"#code-block-marker-open-25
+```nushell" | print
 "> {\"1\":true \" \":false}.\" \"" | nu-highlight | print
 
 {"1":true " ":false}." " | table | print; print ''
 
 "```" | print
 
-"
-To make a copy of a record with new fields, you can use the [spread operator](/book/operators#spread-operator) (`...`):
-" | print
-"```nushell" | print
+"#code-block-marker-open-27
+```nushell" | print
 "> let data = { name: alice, age: 50 }" | nu-highlight | print
 
 let data = { name: alice, age: 50 }
@@ -330,56 +155,40 @@ let data = { name: alice, age: 50 }
 
 "```" | print
 
-"
-## Lists
-
-Lists are ordered sequences of data values. List syntax is very similar to arrays in JSON. However, commas are _not_ required to separate values if Nushell can easily distinguish them!
-" | print
-"```nushell" | print
+"#code-block-marker-open-29
+```nushell" | print
 "> [sam fred george]" | nu-highlight | print
 
 [sam fred george] | table | print; print ''
 
 "```" | print
 
-"
-:::tip
-Lists are equivalent to the individual columns of tables. You can think of a list as essentially being a \"one-column table\" (with no column name). Thus, any command which operates on a column _also_ operates on a list. For instance, [`where`](/commands/docs/where.md) can be used with lists:
-" | print
-"```nushell" | print
+"#code-block-marker-open-31
+```nushell" | print
 "> [bell book candle] | where ($it =~ 'b')" | nu-highlight | print
 
 [bell book candle] | where ($it =~ 'b') | table | print; print ''
 
 "```" | print
 
-"
-:::
-
-Accessing lists' data is done by placing a `.` before a bare integer:
-" | print
-"```nushell" | print
+"#code-block-marker-open-33
+```nushell" | print
 "> [a b c].1" | nu-highlight | print
 
 [a b c].1 | table | print; print ''
 
 "```" | print
 
-"
-To get a sub-list from a list, you can use the [`range`](/commands/docs/range.md) command:
-" | print
-"```nushell" | print
+"#code-block-marker-open-35
+```nushell" | print
 "> [a b c d e f] | range 1..3" | nu-highlight | print
 
 [a b c d e f] | range 1..3 | table | print; print ''
 
 "```" | print
 
-"
-To append one or more lists together, optionally with values interspersed in between, you can use the
-[spread operator](/book/operators#spread-operator) (`...`):
-" | print
-"```nushell" | print
+"#code-block-marker-open-37
+```nushell" | print
 "> let x = [1 2]" | nu-highlight | print
 
 let x = [1 2]
@@ -390,118 +199,72 @@ let x = [1 2]
 
 "```" | print
 
-"
-## Tables
-
-The table is a core data structure in Nushell. As you run commands, you'll see that many of them return tables as output. A table has both rows and columns.
-
-We can create our own tables similarly to how we create a list. Because tables also contain columns and not just values, we pass in the name of the column values:
-" | print
-"```nushell" | print
+"#code-block-marker-open-39
+```nushell" | print
 "> [[column1, column2]; [Value1, Value2] [Value3, Value4]]" | nu-highlight | print
 
 [[column1, column2]; [Value1, Value2] [Value3, Value4]] | table | print; print ''
 
 "```" | print
 
-"
-You can also create a table as a list of records, JSON-style:
-" | print
-"```nushell" | print
+"#code-block-marker-open-41
+```nushell" | print
 "> [{name: sam, rank: 10}, {name: bob, rank: 7}]" | nu-highlight | print
 
 [{name: sam, rank: 10}, {name: bob, rank: 7}] | table | print; print ''
 
 "```" | print
 
-"
-:::tip
-Internally, tables are simply **lists of records**. This means that any command which extracts or isolates a specific row of a table will produce a record. For example, `get 0`, when used on a list, extracts the first value. But when used on a table (a list of records), it extracts a record:
-" | print
-"```nushell" | print
+"#code-block-marker-open-43
+```nushell" | print
 "> [{x:12, y:5}, {x:3, y:6}] | get 0" | nu-highlight | print
 
 [{x:12, y:5}, {x:3, y:6}] | get 0 | table | print; print ''
 
 "```" | print
 
-"
-This is true regardless of which table syntax you use:
-" | print
-"```nushell" | print
+"#code-block-marker-open-45
+```nushell" | print
 "> [[x,y];[12,5],[3,6]] | get 0" | nu-highlight | print
 
 [[x,y];[12,5],[3,6]] | get 0 | table | print; print ''
 
 "```" | print
 
-"
-:::
-
-### Cell Paths
-
-You can combine list and record data access syntax to navigate tables. When used on tables, these access chains are called \"cell paths\".
-
-You can access individual rows by number to obtain records:
-
-@[code](@snippets/types_of_data/cell-paths.sh)
-
-Moreover, you can also access entire columns of a table by name, to obtain lists:
-" | print
-"```nushell" | print
+"#code-block-marker-open-47
+```nushell" | print
 "> [{x:12 y:5} {x:4 y:7} {x:2 y:2}].x" | nu-highlight | print
 
 [{x:12 y:5} {x:4 y:7} {x:2 y:2}].x | table | print; print ''
 
 "```" | print
 
-"
-Of course, these resulting lists don't have the column names of the table. To remove columns from a table while leaving it as a table, you'll commonly use the [`select`](/commands/docs/select.md) command with column names:
-" | print
-"```nushell" | print
+"#code-block-marker-open-49
+```nushell" | print
 "> [{x:0 y:5 z:1} {x:4 y:7 z:3} {x:2 y:2 z:0}] | select y z" | nu-highlight | print
 
 [{x:0 y:5 z:1} {x:4 y:7 z:3} {x:2 y:2 z:0}] | select y z | table | print; print ''
 
 "```" | print
 
-"
-To remove rows from a table, you'll commonly use the [`select`](/commands/docs/select.md) command with row numbers, as you would with a list:
-" | print
-"```nushell" | print
+"#code-block-marker-open-51
+```nushell" | print
 "> [{x:0 y:5 z:1} {x:4 y:7 z:3} {x:2 y:2 z:0}] | select 1 2" | nu-highlight | print
 
 [{x:0 y:5 z:1} {x:4 y:7 z:3} {x:2 y:2 z:0}] | select 1 2 | table | print; print ''
 
 "```" | print
 
-"
-#### Optional cell paths
-
-By default, cell path access will fail if it can't access the requested row or column. To suppress these errors, you can add `?` to a cell path member to mark it as _optional_:
-" | print
-"```nushell" | print
+"#code-block-marker-open-53
+```nushell" | print
 "> [{foo: 123}, {}].foo?" | nu-highlight | print
 
 [{foo: 123}, {}].foo? | table | print; print ''
 
 "```" | print
 
-"
-When using optional cell path members, missing data is replaced with `null`.
-
-## Closures
-
-Closures are anonymous functions that can be passed a value through parameters and _close over_ (i.e. use) a variable outside their scope.
-
-For example, in the command `each { |it| print $it }` the closure is the portion contained in curly braces, `{ |it| print $it }`.
-Closure parameters are specified between a pair of pipe symbols (for example, `|it|`) if necessary.
-You can also use a pipeline input as `$in` in most closures instead of providing an explicit parameter: `each { print $in }`
-
-Closures itself can be bound to a named variable and passed as a parameter.
-To call a closure directly in your code use the [`do`](/commands/docs/do.md) command.
-" | print
-"```nushell" | print
+"#code-block-marker-open-55
+```nushell" | print
 "# Assign a closure to a variable
 let greet = { |name| print $\"Hello ($name)\"}
 do $greet \"Julian\"" | nu-highlight | print
@@ -514,18 +277,8 @@ do $greet "Julian" | table | print; print ''
 
 "```" | print
 
-"
-Closures are a useful way to represent code that can be executed on each row of data.
-It is idiomatic to use `$it` as a parameter name in [`each`](/commands/docs/each.md) blocks, but not required;
-`each { |x| print $x }` works the same way as `each { |it| print $it }`.
-
-## Blocks
-
-Blocks don't close over variables, don't have parameters, and can't be passed as a value.
-However, unlike closures, blocks can access mutable variable in the parent closure.
-For example, mutating a variable inside the block used in an [`if`](/commands/docs/if.md) call is valid:
-" | print
-"```nushell" | print
+"#code-block-marker-open-58
+```nushell" | print
 "mut x = 1
 if true {
     $x += 1000
@@ -542,22 +295,18 @@ print $x | table | print; print ''
 
 "```" | print
 
-"
-## Null
+"#code-block-marker-open-61
+```nushell no-run" | print
+"git checkout featurebranch | null" | nu-highlight | print
 
-Finally, there is `null` which is the language's \"nothing\" value, similar to JSON's \"null\". Whenever Nushell would print the `null` value (outside of a string or data structure), it prints nothing instead. Hence, most of Nushell's file system commands (like [`save`](/commands/docs/save.md) or [`cd`](/commands/docs/cd.md)) produce `null`.
+"```\n```output-numd" | print
 
-You can place `null` at the end of a pipeline to replace the pipeline's output with it, and thus print nothing:
-" | print
-"```nushell no-run
 git checkout featurebranch | null
-```" | print
-"
-:::warning
 
-`null` is not the same as the absence of a value! It is possible for a table to be produced that has holes in some of its rows. Attempting to access this value will not produce `null`, but instead cause an error:
-" | print
-"```nushell try,new-instance" | print
+"```" | print
+
+"#code-block-marker-open-63
+```nushell try,new-instance" | print
 "> [{a:1 b:2} {b:1}]" | nu-highlight | print
 
 /Users/user/.cargo/bin/nu -c "[{a:1 b:2} {b:1}]" | complete | if ($in.exit_code != 0) {get stderr} else {get stdout} | table | print; print ''
@@ -567,9 +316,3 @@ git checkout featurebranch | null
 /Users/user/.cargo/bin/nu -c "[{a:1 b:2} {b:1}].1.a" | complete | if ($in.exit_code != 0) {get stderr} else {get stdout} | table | print; print ''
 
 "```" | print
-
-"
-If you would prefer this to return `null`, mark the cell path member as _optional_ like `.1.a?`.
-
-The absence of a value is (as of Nushell 0.71) printed as the ❎ emoji in interactive output.
-:::" | print

--- a/z_examples/3_book_types_of_data/types_of_data.md_intermed.nu
+++ b/z_examples/3_book_types_of_data/types_of_data.md_intermed.nu
@@ -295,16 +295,6 @@ print $x | table | print; print ''
 
 "```" | print
 
-"#code-block-marker-open-61
-```nushell no-run" | print
-"git checkout featurebranch | null" | nu-highlight | print
-
-"```\n```output-numd" | print
-
-git checkout featurebranch | null
-
-"```" | print
-
 "#code-block-marker-open-63
 ```nushell try,new-instance" | print
 "> [{a:1 b:2} {b:1}]" | nu-highlight | print

--- a/z_examples/3_book_types_of_data/types_of_data.md_intermed_from_readme.nu
+++ b/z_examples/3_book_types_of_data/types_of_data.md_intermed_from_readme.nu
@@ -1,0 +1,300 @@
+# this script was generated automatically using numd
+# https://github.com/nushell-prophet/numd
+
+const init_numd_pwd_const = '/Users/user/git/numd'
+
+"#code-block-marker-open-1
+```nushell" | print
+"> 42 | describe" | nu-highlight | print
+
+42 | describe | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-3
+```nushell" | print
+"> \"-5\" | into int" | nu-highlight | print
+
+"-5" | into int | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-5
+```nushell" | print
+"> \"1.2\" | into float" | nu-highlight | print
+
+"1.2" | into float | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-7
+```nushell" | print
+"> let mybool = 2 > 1" | nu-highlight | print
+
+let mybool = 2 > 1
+
+"> $mybool" | nu-highlight | print
+
+$mybool | table | print; print ''
+
+"> let mybool = ($nu.home-path | path exists)" | nu-highlight | print
+
+let mybool = ($nu.home-path | path exists)
+
+"> $mybool" | nu-highlight | print
+
+$mybool | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-9
+```nushell" | print
+"> 3.14day" | nu-highlight | print
+
+3.14day | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-11
+```nushell" | print
+"> 30day / 1sec  # How many seconds in 30 days?" | nu-highlight | print
+
+30day / 1sec | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-13
+```nushell" | print
+"> 1Gb / 1b" | nu-highlight | print
+
+1Gb / 1b | table | print; print ''
+
+"> 1Gib / 1b" | nu-highlight | print
+
+1Gib / 1b | table | print; print ''
+
+"> (1Gib / 1b) == 2 ** 30" | nu-highlight | print
+
+(1Gib / 1b) == 2 ** 30 | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-15
+```nushell" | print
+"> 0x[1F FF]  # Hexadecimal" | nu-highlight | print
+
+0x[1F FF] | table | print; print ''
+
+"> 0b[1 1010] # Binary" | nu-highlight | print
+
+0b[1 1010] | table | print; print ''
+
+"> 0o[377]    # Octal" | nu-highlight | print
+
+0o[377] | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-17
+```nushell" | print
+"> {name: sam rank: 10}" | nu-highlight | print
+
+{name: sam rank: 10} | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-19
+```nushell" | print
+"> {x:3 y:1} | insert z 0" | nu-highlight | print
+
+{x:3 y:1} | insert z 0 | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-21
+```nushell" | print
+"> {name: sam, rank: 10} | transpose key value" | nu-highlight | print
+
+{name: sam, rank: 10} | transpose key value | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-23
+```nushell" | print
+"> {x:12 y:4}.x" | nu-highlight | print
+
+{x:12 y:4}.x | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-25
+```nushell" | print
+"> {\"1\":true \" \":false}.\" \"" | nu-highlight | print
+
+{"1":true " ":false}." " | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-27
+```nushell" | print
+"> let data = { name: alice, age: 50 }" | nu-highlight | print
+
+let data = { name: alice, age: 50 }
+
+"> { ...$data, hobby: cricket }" | nu-highlight | print
+
+{ ...$data, hobby: cricket } | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-29
+```nushell" | print
+"> [sam fred george]" | nu-highlight | print
+
+[sam fred george] | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-31
+```nushell" | print
+"> [bell book candle] | where ($it =~ 'b')" | nu-highlight | print
+
+[bell book candle] | where ($it =~ 'b') | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-33
+```nushell" | print
+"> [a b c].1" | nu-highlight | print
+
+[a b c].1 | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-35
+```nushell" | print
+"> [a b c d e f] | range 1..3" | nu-highlight | print
+
+[a b c d e f] | range 1..3 | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-37
+```nushell" | print
+"> let x = [1 2]" | nu-highlight | print
+
+let x = [1 2]
+
+"> [...$x 3 ...(4..7 | take 2)]" | nu-highlight | print
+
+[...$x 3 ...(4..7 | take 2)] | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-39
+```nushell" | print
+"> [[column1, column2]; [Value1, Value2] [Value3, Value4]]" | nu-highlight | print
+
+[[column1, column2]; [Value1, Value2] [Value3, Value4]] | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-41
+```nushell" | print
+"> [{name: sam, rank: 10}, {name: bob, rank: 7}]" | nu-highlight | print
+
+[{name: sam, rank: 10}, {name: bob, rank: 7}] | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-43
+```nushell" | print
+"> [{x:12, y:5}, {x:3, y:6}] | get 0" | nu-highlight | print
+
+[{x:12, y:5}, {x:3, y:6}] | get 0 | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-45
+```nushell" | print
+"> [[x,y];[12,5],[3,6]] | get 0" | nu-highlight | print
+
+[[x,y];[12,5],[3,6]] | get 0 | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-47
+```nushell" | print
+"> [{x:12 y:5} {x:4 y:7} {x:2 y:2}].x" | nu-highlight | print
+
+[{x:12 y:5} {x:4 y:7} {x:2 y:2}].x | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-49
+```nushell" | print
+"> [{x:0 y:5 z:1} {x:4 y:7 z:3} {x:2 y:2 z:0}] | select y z" | nu-highlight | print
+
+[{x:0 y:5 z:1} {x:4 y:7 z:3} {x:2 y:2 z:0}] | select y z | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-51
+```nushell" | print
+"> [{x:0 y:5 z:1} {x:4 y:7 z:3} {x:2 y:2 z:0}] | select 1 2" | nu-highlight | print
+
+[{x:0 y:5 z:1} {x:4 y:7 z:3} {x:2 y:2 z:0}] | select 1 2 | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-53
+```nushell" | print
+"> [{foo: 123}, {}].foo?" | nu-highlight | print
+
+[{foo: 123}, {}].foo? | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-55
+```nushell" | print
+"# Assign a closure to a variable
+let greet = { |name| print $\"Hello ($name)\"}
+do $greet \"Julian\"" | nu-highlight | print
+
+"```\n```output-numd" | print
+
+# Assign a closure to a variable
+let greet = { |name| print $"Hello ($name)"}
+do $greet "Julian" | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-58
+```nushell" | print
+"mut x = 1
+if true {
+    $x += 1000
+}
+print $x" | nu-highlight | print
+
+"```\n```output-numd" | print
+
+mut x = 1
+if true {
+    $x += 1000
+}
+print $x | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-63
+```nushell try,new-instance" | print
+"> [{a:1 b:2} {b:1}]" | nu-highlight | print
+
+/Users/user/.cargo/bin/nu -c "[{a:1 b:2} {b:1}]" | complete | if ($in.exit_code != 0) {get stderr} else {get stdout} | table | print; print ''
+
+"> [{a:1 b:2} {b:1}].1.a" | nu-highlight | print
+
+/Users/user/.cargo/bin/nu -c "[{a:1 b:2} {b:1}].1.a" | complete | if ($in.exit_code != 0) {get stderr} else {get stdout} | table | print; print ''
+
+"```" | print

--- a/z_examples/4_book_working_with_lists/working_with_lists.md
+++ b/z_examples/4_book_working_with_lists/working_with_lists.md
@@ -347,9 +347,9 @@ be converted to a separate row with a single column:
 # Show world clock for selected time zones
 > $zones | wrap 'Zone' | upsert Time {|it| (date now | date to-timezone $it.Zone | format date '%Y.%m.%d %H:%M')}
 ╭────────Zone────────┬───────Time───────╮
-│ UTC                │ 2024.11.16 20:50 │
-│ CET                │ 2024.11.16 21:50 │
-│ Europe/Moscow      │ 2024.11.16 23:50 │
-│ Asia/Yekaterinburg │ 2024.11.17 01:50 │
+│ UTC                │ 2024.11.16 20:52 │
+│ CET                │ 2024.11.16 21:52 │
+│ Europe/Moscow      │ 2024.11.16 23:52 │
+│ Asia/Yekaterinburg │ 2024.11.17 01:52 │
 ╰────────Zone────────┴───────Time───────╯
 ```

--- a/z_examples/4_book_working_with_lists/working_with_lists.md
+++ b/z_examples/4_book_working_with_lists/working_with_lists.md
@@ -347,9 +347,9 @@ be converted to a separate row with a single column:
 # Show world clock for selected time zones
 > $zones | wrap 'Zone' | upsert Time {|it| (date now | date to-timezone $it.Zone | format date '%Y.%m.%d %H:%M')}
 ╭────────Zone────────┬───────Time───────╮
-│ UTC                │ 2024.06.17 06:06 │
-│ CET                │ 2024.06.17 08:06 │
-│ Europe/Moscow      │ 2024.06.17 09:06 │
-│ Asia/Yekaterinburg │ 2024.06.17 11:06 │
+│ UTC                │ 2024.11.16 20:50 │
+│ CET                │ 2024.11.16 21:50 │
+│ Europe/Moscow      │ 2024.11.16 23:50 │
+│ Asia/Yekaterinburg │ 2024.11.17 01:50 │
 ╰────────Zone────────┴───────Time───────╯
 ```

--- a/z_examples/4_book_working_with_lists/working_with_lists.md_intermed.nu
+++ b/z_examples/4_book_working_with_lists/working_with_lists.md_intermed.nu
@@ -11,19 +11,8 @@ show_empty: false, padding: {left: 1, right: 1},
 trim: {methodology: truncating, wrapping_try_keep_words: false, truncating_suffix: ...},
 header_on_separator: true, abbreviated_row_count: 1000}
 
-"# Working with lists
-
-## Creating lists
-
-A list is an ordered collection of values.
-You can create a `list` with square brackets, surrounded values separated by spaces and/or commas (for readability).
-For example, `[foo bar baz]` or `[foo, bar, baz]`.
-
-## Updating lists
-
-You can [`update`](/commands/docs/update.md) and [`insert`](/commands/docs/insert.md) values into lists as they flow through the pipeline, for example let's insert the value `10` into the middle of a list:
-" | print
-"```nu" | print
+"#code-block-marker-open-1
+```nu" | print
 "> [1, 2, 3, 4] | insert 2 10" | nu-highlight | print
 
 [1, 2, 3, 4] | insert 2 10 | table | print; print ''
@@ -33,10 +22,8 @@ You can [`update`](/commands/docs/update.md) and [`insert`](/commands/docs/inser
 
 "```" | print
 
-"
-We can also use [`update`](/commands/docs/update.md) to replace the 2nd element with the value `10`.
-" | print
-"```nu" | print
+"#code-block-marker-open-3
+```nu" | print
 "> [1, 2, 3, 4] | update 1 10" | nu-highlight | print
 
 [1, 2, 3, 4] | update 1 10 | table | print; print ''
@@ -46,14 +33,8 @@ We can also use [`update`](/commands/docs/update.md) to replace the 2nd element 
 
 "```" | print
 
-"
-## Removing or adding items from list
-
-In addition to [`insert`](/commands/docs/insert.md) and [`update`](/commands/docs/update.md), we also have [`prepend`](/commands/docs/prepend.md) and [`append`](/commands/docs/append.md). These let you insert to the beginning of a list or at the end of the list, respectively.
-
-For example:
-" | print
-"```nu" | print
+"#code-block-marker-open-5
+```nu" | print
 "let colors = [yellow green]
 let colors = ($colors | prepend red)
 let colors = ($colors | append purple)
@@ -72,10 +53,8 @@ $colors | table | print; print ''
 
 "```" | print
 
-"
-In case you want to remove items from list, there are many ways. [`skip`](/commands/docs/skip.md) allows you skip first rows from input, while [`drop`](/commands/docs/drop.md) allows you to skip specific numbered rows from end of list.
-" | print
-"```nu" | print
+"#code-block-marker-open-8
+```nu" | print
 "let colors = [red yellow green purple]
 let colors = ($colors | skip 1)
 let colors = ($colors | drop 2)
@@ -90,10 +69,8 @@ $colors | table | print; print ''
 
 "```" | print
 
-"
-We also have [`last`](/commands/docs/last.md) and [`first`](/commands/docs/first.md) which allow you to [`take`](/commands/docs/take.md) from the end or beginning of the list, respectively.
-" | print
-"```nu" | print
+"#code-block-marker-open-11
+```nu" | print
 "let colors = [red yellow green purple black magenta]
 let colors = ($colors | last 3)
 $colors # [purple black magenta]" | nu-highlight | print
@@ -106,10 +83,8 @@ $colors | table | print; print ''
 
 "```" | print
 
-"
-And from the beginning of a list,
-" | print
-"```nu" | print
+"#code-block-marker-open-14
+```nu" | print
 "let colors = [yellow green purple]
 let colors = ($colors | first 2)
 $colors # [yellow green]" | nu-highlight | print
@@ -122,14 +97,8 @@ $colors | table | print; print ''
 
 "```" | print
 
-"
-## Iterating over lists
-
-To iterate over the items in a list, use the [`each`](/commands/docs/each.md) command with a [block](types_of_data.html#blocks)
-of Nu code that specifies what to do to each item. The block parameter (e.g. `|it|` in `{ |it| print $it }`) is the current list
-item, but the [`enumerate`](/commands/docs/enumerate.md) filter can be used to provide `index` and `item` values if needed. For example:
-" | print
-"```nu" | print
+"#code-block-marker-open-17
+```nu" | print
 "let names = [Mark Tami Amanda Jeremy]
 $names | each { |it| $\"Hello, ($it)!\" }
 # Outputs \"Hello, Mark!\" and three more similar lines.
@@ -147,12 +116,8 @@ $names | enumerate | each { |it| $"($it.index + 1) - ($it.item)" } | table | pri
 
 "```" | print
 
-"
-The [`where`](/commands/docs/where.md) command can be used to create a subset of a list, effectively filtering the list based on a condition.
-
-The following example gets all the colors whose names end in \"e\".
-" | print
-"```nu" | print
+"#code-block-marker-open-20
+```nu" | print
 "let colors = [red orange yellow green blue purple]
 $colors | where ($it | str ends-with 'e')
 # The block passed to `where` must evaluate to a boolean.
@@ -166,10 +131,8 @@ $colors | where ($it | str ends-with 'e')
 
 "```" | print
 
-"
-In this example, we keep only values higher than `7`.
-" | print
-"```nu" | print
+"#code-block-marker-open-22
+```nu" | print
 "let scores = [7 10 8 6 7]
 $scores | where $it > 7 # [10 8]" | nu-highlight | print
 
@@ -180,14 +143,8 @@ $scores | where $it > 7 | table | print; print ''
 
 "```" | print
 
-"
-The [`reduce`](/commands/docs/reduce.md) command computes a single value from a list.
-It uses a block which takes 2 parameters: the current item (conventionally named `it`) and an accumulator
-(conventionally named `acc`). To specify an initial value for the accumulator, use the `--fold` (`-f`) flag.
-To change `it` to have `index` and `item` values, use the [`enumerate`](/commands/docs/enumerate.md) filter.
-For example:
-" | print
-"```nu" | print
+"#code-block-marker-open-25
+```nu" | print
 "let scores = [3 8 4]
 $\"total = ($scores | reduce { |it, acc| $acc + $it })\" # total = 15
 
@@ -210,14 +167,8 @@ $scores | enumerate | reduce --fold 0 { |it, acc| $acc + $it.index * $it.item } 
 
 "```" | print
 
-"
-## Accessing the list
-
-To access a list item at a given index, use the `$name.index` form where `$name` is a variable that holds a list.
-
-For example, the second element in the list below can be accessed with `$names.1`.
-" | print
-"```nu" | print
+"#code-block-marker-open-28
+```nu" | print
 "let names = [Mark Tami Amanda Jeremy]
 $names.1 # gives Tami" | nu-highlight | print
 
@@ -228,10 +179,8 @@ $names.1 | table | print; print ''
 
 "```" | print
 
-"
-If the index is in some variable `$index` we can use the `get` command to extract the item from the list.
-" | print
-"```nu" | print
+"#code-block-marker-open-31
+```nu" | print
 "let names = [Mark Tami Amanda Jeremy]
 let index = 1
 $names | get $index # gives Tami" | nu-highlight | print
@@ -244,14 +193,8 @@ $names | get $index | table | print; print ''
 
 "```" | print
 
-"
-The [`length`](/commands/docs/length.md) command returns the number of items in a list.
-For example, `[red green blue] | length` outputs `3`.
-
-The [`is-empty`](/commands/docs/is-empty.md) command determines whether a string, list, or table is empty.
-It can be used with lists as follows:
-" | print
-"```nu" | print
+"#code-block-marker-open-34
+```nu" | print
 "let colors = [red green blue]
 $colors | is-empty # false
 
@@ -268,10 +211,8 @@ $colors | is-empty | table | print; print ''
 
 "```" | print
 
-"
-The `in` and `not-in` operators are used to test whether a value is in a list. For example:
-" | print
-"```nu" | print
+"#code-block-marker-open-37
+```nu" | print
 "let colors = [red green blue]
 'blue' in $colors # true
 'yellow' in $colors # false
@@ -286,12 +227,8 @@ let colors = [red green blue]
 
 "```" | print
 
-"
-The [`any`](/commands/docs/any.md) command determines if any item in a list
-matches a given condition.
-For example:
-" | print
-"```nu" | print
+"#code-block-marker-open-40
+```nu" | print
 "let colors = [red green blue]
 # Do any color names end with \"e\"?
 $colors | any {|it| $it | str ends-with \"e\" } # true
@@ -324,12 +261,8 @@ $scores | any {|it| $it mod 2 == 1 } | table | print; print ''
 
 "```" | print
 
-"
-The [`all`](/commands/docs/all.md) command determines if every item in a list
-matches a given condition.
-For example:
-" | print
-"```nu" | print
+"#code-block-marker-open-43
+```nu" | print
 "let colors = [red green blue]
 # Do all color names end with \"e\"?
 $colors | all {|it| $it | str ends-with \"e\" } # false
@@ -362,15 +295,8 @@ $scores | all {|it| $it mod 2 == 0 } | table | print; print ''
 
 "```" | print
 
-"
-## Converting the list
-
-The [`flatten`](/commands/docs/flatten.md) command creates a new list from an existing list
-by adding items in nested lists to the top-level list.
-This can be called multiple times to flatten lists nested at any depth.
-For example:
-" | print
-"```nu" | print
+"#code-block-marker-open-46
+```nu" | print
 "[1 [2 3] 4 [5 6]] | flatten # [1 2 3 4 5 6]
 
 [[1 2] [3 [4 5 [6 7 8]]]] | flatten | flatten | flatten" | nu-highlight | print
@@ -383,18 +309,17 @@ For example:
 
 "```" | print
 
-"
-The [`wrap`](/commands/docs/wrap.md) command converts a list to a table. Each list value will
-be converted to a separate row with a single column:
-" | print
-"```nu no-run
-> let zones = [UTC CET Europe/Moscow Asia/Yekaterinburg]
-# Show world clock for selected time zones
-> $zones | wrap 'Zone' | upsert Time {|it| (date now | date to-timezone $it.Zone | format date '%Y.%m.%d %H:%M')}
-╭────────Zone────────┬───────Time───────╮
-│ UTC                │ 2024.06.17 06:06 │
-│ CET                │ 2024.06.17 08:06 │
-│ Europe/Moscow      │ 2024.06.17 09:06 │
-│ Asia/Yekaterinburg │ 2024.06.17 11:06 │
-╰────────Zone────────┴───────Time───────╯
-```" | print
+"#code-block-marker-open-49
+```nu no-run" | print
+"> let zones = [UTC CET Europe/Moscow Asia/Yekaterinburg]" | nu-highlight | print
+
+let zones = [UTC CET Europe/Moscow Asia/Yekaterinburg]
+
+"# Show world clock for selected time zones" | nu-highlight | print
+
+
+"> $zones | wrap 'Zone' | upsert Time {|it| (date now | date to-timezone $it.Zone | format date '%Y.%m.%d %H:%M')}" | nu-highlight | print
+
+$zones | wrap 'Zone' | upsert Time {|it| (date now | date to-timezone $it.Zone | format date '%Y.%m.%d %H:%M')} | table | print; print ''
+
+"```" | print

--- a/z_examples/4_book_working_with_lists/working_with_lists.md_intermed.nu
+++ b/z_examples/4_book_working_with_lists/working_with_lists.md_intermed.nu
@@ -308,18 +308,3 @@ $scores | all {|it| $it mod 2 == 0 } | table | print; print ''
 [[1 2] [3 [4 5 [6 7 8]]]] | flatten | flatten | flatten | table | print; print ''
 
 "```" | print
-
-"#code-block-marker-open-49
-```nu no-run" | print
-"> let zones = [UTC CET Europe/Moscow Asia/Yekaterinburg]" | nu-highlight | print
-
-let zones = [UTC CET Europe/Moscow Asia/Yekaterinburg]
-
-"# Show world clock for selected time zones" | nu-highlight | print
-
-
-"> $zones | wrap 'Zone' | upsert Time {|it| (date now | date to-timezone $it.Zone | format date '%Y.%m.%d %H:%M')}" | nu-highlight | print
-
-$zones | wrap 'Zone' | upsert Time {|it| (date now | date to-timezone $it.Zone | format date '%Y.%m.%d %H:%M')} | table | print; print ''
-
-"```" | print

--- a/z_examples/5_simple_nu_table/simple_nu_table.md_intermed.nu
+++ b/z_examples/5_simple_nu_table/simple_nu_table.md_intermed.nu
@@ -11,15 +11,16 @@ show_empty: false, padding: {left: 1, right: 1},
 trim: {methodology: truncating, wrapping_try_keep_words: false, truncating_suffix: ...},
 header_on_separator: true, abbreviated_row_count: 1000}
 
-"```nushell" | print
+"#code-block-marker-open-0
+```nushell" | print
 "> $env.numd?" | nu-highlight | print
 
 $env.numd? | table | print; print ''
 
 "```" | print
 
-"" | print
-"```nushell" | print
+"#code-block-marker-open-2
+```nushell" | print
 "[[a b c]; [1 2 3]]" | nu-highlight | print
 
 "```\n```output-numd" | print
@@ -28,8 +29,8 @@ $env.numd? | table | print; print ''
 
 "```" | print
 
-"" | print
-"```nushell" | print
+"#code-block-marker-open-5
+```nushell" | print
 "[[column long_text];
 
 ['value_1' ('Veniam cillum et et. Et et qui enim magna. Qui enim, magna eu aute lorem.' +

--- a/z_examples/6_edge_cases/error-with-try.md_intermed.nu
+++ b/z_examples/6_edge_cases/error-with-try.md_intermed.nu
@@ -11,14 +11,6 @@ show_empty: false, padding: {left: 1, right: 1},
 trim: {methodology: truncating, wrapping_try_keep_words: false, truncating_suffix: ...},
 header_on_separator: true, abbreviated_row_count: 1000}
 
-"#code-block-marker-open-0
-```nushell no-run" | print
-"> lssomething" | nu-highlight | print
-
-lssomething | table | print; print ''
-
-"```" | print
-
 "#code-block-marker-open-2
 ```nushell try, new-instance" | print
 "> lssomething" | nu-highlight | print

--- a/z_examples/6_edge_cases/error-with-try.md_intermed.nu
+++ b/z_examples/6_edge_cases/error-with-try.md_intermed.nu
@@ -11,16 +11,16 @@ show_empty: false, padding: {left: 1, right: 1},
 trim: {methodology: truncating, wrapping_try_keep_words: false, truncating_suffix: ...},
 header_on_separator: true, abbreviated_row_count: 1000}
 
-"```nushell no-run
-> lssomething
-╭───────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ msg   │ External command failed                                                                                                                                                                    │
-│ debug │ ExternalCommand { label: \"Command `lssomething` not found\", help: \"`lssomething` is neither a Nushell built-in or a known external command\", span: Span { start: 1967901, end: 1967912 } } │
-│ raw   │ ExternalCommand { label: \"Command `lssomething` not found\", help: \"`lssomething` is neither a Nushell built-in or a known external command\", span: Span { start: 1967901, end: 1967912 } } │
-╰───────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-```" | print
-"" | print
-"```nushell try, new-instance" | print
+"#code-block-marker-open-0
+```nushell no-run" | print
+"> lssomething" | nu-highlight | print
+
+lssomething | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-2
+```nushell try, new-instance" | print
 "> lssomething" | nu-highlight | print
 
 /Users/user/.cargo/bin/nu -c "lssomething" | complete | if ($in.exit_code != 0) {get stderr} else {get stdout} | table | print; print ''

--- a/z_examples/6_edge_cases/raw_strings_test.md_intermed.nu
+++ b/z_examples/6_edge_cases/raw_strings_test.md_intermed.nu
@@ -11,9 +11,8 @@ show_empty: false, padding: {left: 1, right: 1},
 trim: {methodology: truncating, wrapping_try_keep_words: false, truncating_suffix: ...},
 header_on_separator: true, abbreviated_row_count: 1000}
 
-"raw strings test
-" | print
-"```nu" | print
+"#code-block-marker-open-1
+```nu" | print
 "let $two_single_lines_text = r#'\"High up in the mountains, a Snake crawled and lay in a damp gorge, coiled
     into a knot, staring out at the sea.'#" | nu-highlight | print
 
@@ -24,8 +23,8 @@ let $two_single_lines_text = r#'"High up in the mountains, a Snake crawled and l
 
 "```" | print
 
-"" | print
-"```nu" | print
+"#code-block-marker-open-3
+```nu" | print
 "$two_single_lines_text" | nu-highlight | print
 
 "```\n```output-numd" | print

--- a/z_examples/6_edge_cases/simple_markdown_first_block.md
+++ b/z_examples/6_edge_cases/simple_markdown_first_block.md
@@ -1,0 +1,27 @@
+```nu
+let $var1 = 'foo'
+```
+
+## Example 2
+
+```nu
+# This block will produce some output in a separate block
+$var1 | path join 'baz' 'bar'
+```
+
+Output:
+
+```
+foo/baz/bar
+```
+
+## Example 3
+
+```nu
+# This block will output results inline
+> whoami
+user
+
+> 2 + 2
+4
+```

--- a/z_examples/6_edge_cases/simple_markdown_first_block.md_intermed.nu
+++ b/z_examples/6_edge_cases/simple_markdown_first_block.md_intermed.nu
@@ -1,0 +1,49 @@
+# this script was generated automatically using numd
+# https://github.com/nushell-prophet/numd
+
+const init_numd_pwd_const = '/Users/user/git/numd'
+
+# numd config loaded from `/Users/user/git/numd/numd_config_example1.yaml`
+
+$env.config.footer_mode = 'always';
+$env.config.table = {mode: rounded, index_mode: never,
+show_empty: false, padding: {left: 1, right: 1},
+trim: {methodology: truncating, wrapping_try_keep_words: false, truncating_suffix: ...},
+header_on_separator: true, abbreviated_row_count: 1000}
+
+"#code-block-marker-open-0
+```nu" | print
+"let $var1 = 'foo'" | nu-highlight | print
+
+"```\n```output-numd" | print
+
+let $var1 = 'foo'
+
+"```" | print
+
+"#code-block-marker-open-2
+```nu" | print
+"# This block will produce some output in a separate block
+$var1 | path join 'baz' 'bar'" | nu-highlight | print
+
+"```\n```output-numd" | print
+
+# This block will produce some output in a separate block
+$var1 | path join 'baz' 'bar' | table | print; print ''
+
+"```" | print
+
+"#code-block-marker-open-5
+```nu" | print
+"# This block will output results inline" | nu-highlight | print
+
+
+"> whoami" | nu-highlight | print
+
+whoami | table | print; print ''
+
+"> 2 + 2" | nu-highlight | print
+
+2 + 2 | table | print; print ''
+
+"```" | print

--- a/z_examples/99_strip_markdown/error-with-try.nu
+++ b/z_examples/99_strip_markdown/error-with-try.nu
@@ -1,7 +1,3 @@
 
-    # ```nushell no-run
-lssomething
-
-
     # ```nushell try, new-instance
 lssomething

--- a/z_examples/99_strip_markdown/numd_commands_explanations.nu
+++ b/z_examples/99_strip_markdown/numd_commands_explanations.nu
@@ -16,7 +16,7 @@ let $file = $init_numd_pwd_const | path join z_examples 1_simple_markdown simple
 
 let $md_orig = open -r $file | toggle-output-fences
 let $md_orig_table = $md_orig | find-code-blocks
-$md_orig_table
+$md_orig_table | table -e
 
 
     # ```nu indent-output

--- a/z_examples/99_strip_markdown/simple_markdown_first_block.nu
+++ b/z_examples/99_strip_markdown/simple_markdown_first_block.nu
@@ -1,0 +1,14 @@
+
+    # ```nu
+let $var1 = 'foo'
+
+
+    # ```nu
+# This block will produce some output in a separate block
+$var1 | path join 'baz' 'bar'
+
+
+    # ```nu
+# This block will output results inline
+whoami
+2 + 2

--- a/z_examples/99_strip_markdown/types_of_data.nu
+++ b/z_examples/99_strip_markdown/types_of_data.nu
@@ -130,10 +130,6 @@ if true {
 print $x
 
 
-    # ```nushell no-run
-git checkout featurebranch | null
-
-
     # ```nushell try,new-instance
 [{a:1 b:2} {b:1}]
 [{a:1 b:2} {b:1}].1.a

--- a/z_examples/99_strip_markdown/working_with_lists.nu
+++ b/z_examples/99_strip_markdown/working_with_lists.nu
@@ -131,9 +131,3 @@ $scores | all {|it| $it mod 2 == 0 } # false
 [1 [2 3] 4 [5 6]] | flatten # [1 2 3 4 5 6]
 
 [[1 2] [3 [4 5 [6 7 8]]]] | flatten | flatten | flatten
-
-
-    # ```nu no-run
-let zones = [UTC CET Europe/Moscow Asia/Yekaterinburg]
-# Show world clock for selected time zones
-$zones | wrap 'Zone' | upsert Time {|it| (date now | date to-timezone $it.Zone | format date '%Y.%m.%d %H:%M')}


### PR DESCRIPTION
- added logic to define actions on blocks of code
- renamed variables 
- formatted code