### PR TITLE
format scripts with topiary, add kv for writing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Experienced nushell users can understand the logic better by looking at [example
 //   --no-backup: overwrite the existing `.md` file without backup
 //   --no-save: do not save changes to the `.md` file
 //   --no-stats: do not output stats of changes
-//   --intermed-script <path>: optional path for keeping intermediate script (useful for debugging purposes). If not set, the temporary intermediate script will be deleted.
+//   --save-intermed-script <path>: optional path for keeping intermediate script (useful for debugging purposes). If not set, the temporary intermediate script will be deleted.
 //   --no-fail-on-error: skip errors (and don't update markdown in case of errors anyway)
 //   --prepend-code <string>: prepend code into the intermediate script, useful for customizing Nushell output settings
 //   --table-width <int>: set the `table --width` option value
@@ -97,7 +97,7 @@ By default, `numd` provides basic stats on changes made.
 
 ### Styling outputs
 
-It is possible to set Nushell visual settings (and all the others) using the `--prepend-itermid` option. Just pass a code there to be prepended into our intermed-script.nu and executed before all parts of the code.
+It is possible to set Nushell visual settings (and all the others) using the `--save-intermed-script` option. Just pass a code there to be prepended into our save-intermed-script.nu and executed before all parts of the code.
 
 ```nushell indent-output
 let path = $nu.temp-path | path join simple_nu_table.md
@@ -232,7 +232,7 @@ Sun, 22 Dec 2024 19:11:35 -0300 (3 days ago)
 # save intermed nushell script to `types_of_data.md_intermed_from_readme.nu`
 [z_examples 3_book_types_of_data types_of_data.md]
 | path join
-| numd run $in --no-backup --intermed-script $'($in)_intermed_from_readme.nu'
+| numd run $in --no-backup --save-intermed-script $'($in)_intermed_from_readme.nu'
 ```
 
 ## Development and testing

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Execute blocks of nushell code within markdown documents, write results back to your `.md` document, or output them to the terminal.
 
-`numd` is inspired by [R Markdown](https://bookdown.org/yihui/rmarkdown/basics.html#basics).
-
 ## Quickstart
 
 ```nushell no-run

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-<h1 align="center">numd</h1>
-<h3 align="center">reproducible Nushell Markdown documents</h3>
+# numd - reproducible Nushell Markdown documents
 
 Execute blocks of nushell code within markdown documents, write results back to your `.md` document, or output them to the terminal.
 

--- a/numd/commands.nu
+++ b/numd/commands.nu
@@ -221,7 +221,7 @@ export def 'parse-help' [
 
     $existing_sections
     | merge $elements
-    | transpose -idr
+    | transpose --as-record --ignore-titles --header-row
     | if ($in.Flags? == null) {} else {update 'Flags' {where $it !~ '-h, --help'}}
     | if ($in.Flags? | length) == 1 {reject 'Flags'} else {} # todo now flags contain fields with empty row
     | if ($in.Description? | default '' | split list '' | length) > 1 {

--- a/numd/commands.nu
+++ b/numd/commands.nu
@@ -35,6 +35,7 @@ export def run [
         # which will only work if we execute the intermediate script from the same folder.
 
     decortate-original-code-blocks $original_md_table
+    | kv-catch -p decortate-original-code-blocks
     | generate-intermediate-script
     | save -f $intermediate_script_path
 

--- a/numd/commands.nu
+++ b/numd/commands.nu
@@ -874,9 +874,11 @@ export def scan [ # -> list<any>
 # Helper command to check if `$env.kv-catch == true` to set kv var
 def kv-catch [
     $key
-    $value
+    $value?
     -p # pass further
 ] {
+    let $value = if $value == null {$in} else {$value}
+
     if $env.kv-catch? == true {
         kv set $key $value
     }

--- a/numd/commands.nu
+++ b/numd/commands.nu
@@ -10,7 +10,7 @@ export def run [
     --no-backup # overwrite the existing `.md` file without backup
     --no-save # do not save changes to the `.md` file
     --no-stats # do not output stats of changes
-    --intermed-script: path # optional path for keeping intermediate script (useful for debugging purposes). If not set, the temporary intermediate script will be deleted.
+    --save-intermed-script: path # optional path for keeping intermediate script (useful for debugging purposes). If not set, the temporary intermediate script will be deleted.
     --no-fail-on-error # skip errors (and don't update markdown in case of errors anyway)
     --prepend-code: string # prepend code into the intermediate script, useful for customizing Nushell output settings
     --table-width: int # set the `table --width` option value
@@ -29,7 +29,7 @@ export def run [
 
     load-config $config_path --prepend_code $prepend_code --table_width $table_width
 
-    let $intermediate_script_path = $intermed_script
+    let $intermediate_script_path = $save_intermed_script
         | default ( $file | modify-path --prefix $'numd-temp-(generate-timestamp)' --extension '.nu' )
         # We don't use a temp directory here as the code in `md` files might contain relative paths,
         # which will only work if we execute the intermediate script from the same folder.
@@ -53,8 +53,8 @@ export def run [
         | clean-markdown
         | toggle-output-fences --back
 
-    # if $intermed_script param wasn't set - remove the temporary intermediate script
-    if $intermed_script == null { rm $intermediate_script_path }
+    # if $save_intermed_script param wasn't set - remove the temporary intermediate script
+    if $save_intermed_script == null { rm $intermediate_script_path }
 
     let $output_path = $result_md_path | default $file
 

--- a/numd/commands.nu
+++ b/numd/commands.nu
@@ -300,7 +300,7 @@ export def find-code-blocks []: string -> table {
 
 export def match-action [
     $row_type: string
-] {
+]: nothing -> string {
     match $row_type {
         'text' => {'print-as-it-is'}
         '```output-numd' => {'delete'}

--- a/numd/commands.nu
+++ b/numd/commands.nu
@@ -461,7 +461,7 @@ export def toggle-output-fences [
     a = "\n```\n\nOutput:\n\n```\n" # I set variables here to prevent collecting $in var
     b = "\n```\n```output-numd\n"
     --back
-] {
+]: string -> string {
     if $back {
         str replace --all $b $a
     } else {

--- a/numd/commands.nu
+++ b/numd/commands.nu
@@ -1,3 +1,5 @@
+use kv # I use kv here for catching real data structures for test cases
+
 # Run Nushell code blocks in a markdown file, output results back to the `.md`, and optionally to terminal
 export def run [
     file: path # path to a `.md` file containing Nushell code to be executed

--- a/numd/commands.nu
+++ b/numd/commands.nu
@@ -453,6 +453,9 @@ export def clean-markdown []: string -> string {
 
 # Replacement is needed to distinguish the blocks with outputs from blocks with just ```.
 # `find-code-blocks` works only with lines without knowing the previous lines.
+#
+# > "```nu\n123\n```\n\nOutput:\n\n```\n123" | toggle-output-fences | to json
+# "```nu\n123\n```\n```output-numd\n123"
 export def toggle-output-fences [
     a = "\n```\n\nOutput:\n\n```\n" # I set variables here to prevent collecting $in var
     b = "\n```\n```output-numd\n"

--- a/numd/commands.nu
+++ b/numd/commands.nu
@@ -35,7 +35,7 @@ export def run [
         | toggle-output-fences # should be unnecessary for new files
         | find-code-blocks
 
-    # $original_md_table | save -f ($file + '_original_md_table.json')
+    kv-catch original_md_table $original_md_table
 
     load-config $config_path --prepend_code $prepend_code --table_width $table_width
 

--- a/numd/commands.nu
+++ b/numd/commands.nu
@@ -1,15 +1,5 @@
 use kv # I use kv here for catching real data structures for test cases
 
-# Helper command to check if `$env.kv-catch == true` to set kv var
-def kv-catch [
-    $key
-    $value
-] {
-    if $env.kv-catch? == true {
-        kv set $key $value
-    }
-}
-
 # Run Nushell code blocks in a markdown file, output results back to the `.md`, and optionally to terminal
 export def run [
     file: path # path to a `.md` file containing Nushell code to be executed
@@ -875,5 +865,15 @@ export def scan [ # -> list<any>
         $in | skip
     } else {
         $in
+    }
+}
+
+# Helper command to check if `$env.kv-catch == true` to set kv var
+def kv-catch [
+    $key
+    $value
+] {
+    if $env.kv-catch? == true {
+        kv set $key $value
     }
 }

--- a/numd/commands.nu
+++ b/numd/commands.nu
@@ -46,7 +46,9 @@ export def run [
         } else {}
         | str replace -ar "\n{2,}```\n" "\n```\n"
         | lines
+        | kv-catch -p before-extract-block-index
         | extract-block-index
+        | kv-catch -p extract-block-index
 
     # $nu_res_with_block_index | save -f ($file + '_intermed_exec.json')
 

--- a/numd/commands.nu
+++ b/numd/commands.nu
@@ -1,5 +1,15 @@
 use kv # I use kv here for catching real data structures for test cases
 
+# Helper command to check if `$env.kv-catch == true` to set kv var
+def kv-catch [
+    $key
+    $value
+] {
+    if $env.kv-catch? == true {
+        kv set $key $value
+    }
+}
+
 # Run Nushell code blocks in a markdown file, output results back to the `.md`, and optionally to terminal
 export def run [
     file: path # path to a `.md` file containing Nushell code to be executed

--- a/numd/commands.nu
+++ b/numd/commands.nu
@@ -46,7 +46,7 @@ export def run [
         } else {}
         | str replace -ar "\n{2,}```\n" "\n```\n"
         | lines
-        | extract-block-index $in
+        | extract-block-index
 
     # $nu_res_with_block_index | save -f ($file + '_intermed_exec.json')
 
@@ -102,7 +102,7 @@ export def clear-outputs [
         | prepend (mark-code-block $block_index)
     }
     | flatten
-    | extract-block-index $in
+    | extract-block-index
     | if $strip_markdown {
         get line
         | each {
@@ -397,11 +397,8 @@ export def execute-block-lines [
 }
 
 # Parse block indices from Nushell output lines and return a table with the original markdown line numbers.
-export def extract-block-index [
-    $nu_res_stdout_lines: list
-]: nothing -> table {
-    let $clean_lines = $nu_res_stdout_lines
-        | skip until {|x| $x =~ (mark-code-block)}
+export def extract-block-index []: list -> table {
+    let $clean_lines = skip until {|x| $x =~ (mark-code-block)}
 
     let $block_index = $clean_lines
         | each {

--- a/numd/commands.nu
+++ b/numd/commands.nu
@@ -875,8 +875,11 @@ export def scan [ # -> list<any>
 def kv-catch [
     $key
     $value
+    -p # pass further
 ] {
     if $env.kv-catch? == true {
         kv set $key $value
     }
+
+    if $p {$value}
 }

--- a/numd/kv/commands.nu
+++ b/numd/kv/commands.nu
@@ -1,0 +1,249 @@
+# Nushell Key-Value Store (kv)
+# Original version by @clipplerblood
+# https://discord.com/channels/601130461678272522/615253963645911060/1149709351821516900
+
+# Alias to avoid conflict with the custom 'get' function
+alias core_get = get
+alias core_ls = ls
+
+# Display the KV store as a table or list files in the values folder
+export def ls [] {
+    # Load the KV store and display it as a table with modification dates
+    load-kv
+    | items {|key, value| { name: $key, filename: $value } }
+    | insert modified {|item|
+        core_ls $item.filename | core_get 0.modified
+    }
+    | sort-by modified --reverse
+    | update modified { date humanize }
+    | select name modified
+}
+
+# Return the path to the KV store file or values folder
+def kv-path [
+    --values_folder  # Return the path to the values folder instead of the KV file
+]: nothing -> path {
+    $env.kv?.path?
+    | if $in != null {} else {
+        $nu.home-path
+        | path join '.config' 'nushell' 'kv'
+    }
+    | if $values_folder {
+        # Return the path to the 'values' folder
+        path join 'values'
+    } else {
+        # Return the path to the 'kv.nuon' file
+        path join 'kv.nuon'
+    }
+}
+
+export def --env init [
+    dir?: path
+    --reset
+] {
+    if $dir != null { $env.kv.path = $dir }
+
+    let $kv_file = kv-path
+
+    if $reset or not ($kv_file | path exists) {
+        # Create the values folder and initialize an empty KV store
+        mkdir (kv-path --values_folder)
+        {} | save --force $kv_file
+    }
+}
+
+# Load the KV store, creating it and the values folder if they don't exist
+def load-kv []: nothing -> record {
+    # Open and return the KV store
+    kv-path | open
+}
+
+# Generate a timestamped filename
+def date-now [] {
+    date now | format date "%Y%m%d_%H%M%S_%f"
+}
+
+# Set a value in the KV store, optionally taking input from the pipeline
+export def set [
+    key: string = 'last'          # Specify the key to set
+    value?: any                   # Provide the value to set (optional if used in a pipeline)
+    --return-to-stdout (-p)       # Output the input value back to the pipeline
+    --extension (-e): string = '' # Specify the file extension for saving
+]: any -> any {
+    let $input = $in # we store input here as it might be needed to return at the end of this command
+    let $value_to_store = if $value == null { $input } else { $value }
+    let $value_type = $value_to_store | describe
+
+    # Determine the file extension based on the value type
+    let $file_extension = if $extension != '' {
+            $extension
+        } else if $value_type =~ 'table|list|record|binary' {
+            'msgpackz'
+        } else if $value_type == 'string' {
+            'txt'  # 'msgpackz' can't store primitives in some versions
+        } else {
+            'nuon'
+        }
+
+    # Generate a unique filename for the value
+    let $file_path = kv-path --values_folder
+        | path join $"($key)_(date-now).($file_extension)"
+
+    # Save the value to the file
+    $value_to_store | save $file_path
+
+    # Update the KV store
+    load-kv
+    | reject $key -i # Remove existing key to sort chronologically
+    | insert $key $file_path
+    | save -f (kv-path)
+
+    # Output the input value if -p is specified
+    if $return_to_stdout { return $input }
+}
+
+# Get a value from the KV store
+export def get [
+    key: string@'nu-complete-key-names' = 'last'  # Specify the key to retrieve
+    --ignore-errors (-i)
+] {
+    load-kv
+    | if $key in $in {
+        core_get $key | open
+    } else {
+        if $ignore_errors { return } else {
+            error make {msg: $'ther is no `($key)` key in `(kv-path)`'}
+        }
+    }
+}
+
+# Retrieve a file by its filename from the values folder
+export def get-file [
+    filename: string@'nu-complete-file-names' = ''  # Specify the filename to retrieve
+] {
+    if $filename == '' {
+        core_ls (kv-path --values_folder)
+        | sort-by modified -r
+    } else {
+        kv-path --values_folder
+        | path join $filename
+        | open
+    }
+}
+
+# Delete a key from the KV store
+export def del [
+    key: string@'nu-complete-key-names' = 'last'  # Specify the key to delete
+] {
+    # Remove the key and save the KV store
+    load-kv | reject $key | save -f (kv-path)
+}
+
+# Reset the KV store (leave all files in the 'values' folder)
+export def reset [] {
+    # Confirm before resetting
+    [false true]
+    | input list 'confirm'
+    | if $in {
+        {} | save -f (kv-path)
+    }
+}
+
+# Push a value to a list in the KV store
+export def push [
+    key: string                 # Specify the key to push to
+    value?: any                 # Provide the value to push (optional if used in a pipeline)
+    -p                          # Output the input value back to the pipeline
+    -u                          # Ensure uniqueness in the list
+]: any -> any {
+    let $input = $in
+    let $value_to_push = if $value != null {
+            $value
+        } else if $input != null {
+            $input
+        } else {
+            error make { msg: "No value provided to push" }
+        }
+
+    let $kv_store = load-kv
+
+    if not ($key in $kv_store) {
+        # Key does not exist; create a new list with the value
+        $kv_store
+        | upsert $key [$value_to_push]
+        | save -f (kv-path)
+    } else {
+        # Key exists; retrieve and update the list
+        let $stored_list = $kv_store | core_get $key
+        if not ($stored_list | describe | str starts-with 'list') {
+            error make { msg: $"Key '($key)' is not associated with a list" }
+        }
+
+        let $updated_list = if $u {
+                # Ensure uniqueness
+                $stored_list | where {|x| $x != $value_to_push} | append $value_to_push
+            } else {
+                # Simply append the new value
+                $stored_list | append $value_to_push
+            }
+
+        # Update the KV store
+        $kv_store | upsert $key $updated_list | save -f (kv-path)
+    }
+
+    # Output the input value if -p is specified
+    if $p { return $value_to_push }
+}
+
+# Get the last value of a list in the KV store.
+# Not an actual "pop". To remove the element, use the flag -r.
+# Example:
+# > kv set my-stack ["hello", "world"]
+# > kv pop my-stack
+# world
+#
+# > kv pop my-stack
+# hello
+#
+# > kv get my-stack
+# ╭────────────╮
+# │ empty list │
+# ╰────────────╯
+export def "pop" [
+    key  # Key to get
+] {
+    let $stored = get $key
+    let $value = $stored
+        | if ($in | length) == 0 { return } else { last }
+
+    if ($stored | length) > 0 { set $key ($stored | drop) }
+
+    $value
+}
+
+# Autocompletion for key names
+def nu-complete-key-names [] {
+    main
+    | rename value description
+    | {
+        completions : $in,
+        options: {
+            sort: false
+        }
+    }
+}
+
+# Autocompletion for file names in the values folder
+def nu-complete-file-names [] {
+    core_ls -s (kv-path --values_folder)
+    | sort-by modified --reverse
+    | select name modified
+    | update modified { date humanize }
+    | rename value description
+}
+
+def history-last [] {
+    open $nu.history-path
+    | query db "select * from history order by id desc limit 1"
+    | get command_line.0
+}

--- a/numd/kv/commands.nu
+++ b/numd/kv/commands.nu
@@ -10,7 +10,7 @@ alias core_ls = ls
 export def ls [] {
     # Load the KV store and display it as a table with modification dates
     load-kv
-    | items {|key, value| { name: $key, filename: $value } }
+    | items {|key, value| {name: $key filename: $value} }
     | insert modified {|item|
         core_ls $item.filename | core_get 0.modified
     }
@@ -21,10 +21,10 @@ export def ls [] {
 
 # Return the path to the KV store file or values folder
 def kv-path [
-    --values_folder  # Return the path to the values folder instead of the KV file
+    --values_folder # Return the path to the values folder instead of the KV file
 ]: nothing -> path {
     $env.kv?.path?
-    | if $in != null {} else {
+    | if $in != null { } else {
         $nu.home-path
         | path join '.config' 'nushell' 'kv'
     }
@@ -65,9 +65,9 @@ def date-now [] {
 
 # Set a value in the KV store, optionally taking input from the pipeline
 export def set [
-    key: string = 'last'          # Specify the key to set
-    value?: any                   # Provide the value to set (optional if used in a pipeline)
-    --return-to-stdout (-p)       # Output the input value back to the pipeline
+    key: string = 'last' # Specify the key to set
+    value?: any # Provide the value to set (optional if used in a pipeline)
+    --return-to-stdout (-p) # Output the input value back to the pipeline
     --extension (-e): string = '' # Specify the file extension for saving
 ]: any -> any {
     let input = $in # we store input here as it might be needed to return at the end of this command
@@ -76,18 +76,18 @@ export def set [
 
     # Determine the file extension based on the value type
     let file_extension = if $extension != '' {
-            $extension
-        } else if $value_type =~ 'table|list|record|binary' {
-            'msgpackz'
-        } else if $value_type == 'string' {
-            'txt'  # 'msgpackz' can't store primitives in some versions
-        } else {
-            'nuon'
-        }
+        $extension
+    } else if $value_type =~ 'table|list|record|binary' {
+        'msgpackz'
+    } else if $value_type == 'string' {
+        'txt' # 'msgpackz' can't store primitives in some versions
+    } else {
+        'nuon'
+    }
 
     # Generate a unique filename for the value
     let file_path = kv-path --values_folder
-        | path join $"($key)_(date-now).($file_extension)"
+    | path join $"($key)_(date-now).($file_extension)"
 
     # Save the value to the file
     $value_to_store | save $file_path
@@ -104,7 +104,7 @@ export def set [
 
 # Get a value from the KV store
 export def get [
-    key: string@'nu-complete-key-names' = 'last'  # Specify the key to retrieve
+    key: string@'nu-complete-key-names' = 'last' # Specify the key to retrieve
     --ignore-errors (-i)
 ] {
     load-kv
@@ -119,7 +119,7 @@ export def get [
 
 # Retrieve a file by its filename from the values folder
 export def get-file [
-    filename: string@'nu-complete-file-names' = ''  # Specify the filename to retrieve
+    filename: string@'nu-complete-file-names' = '' # Specify the filename to retrieve
 ] {
     if $filename == '' {
         core_ls (kv-path --values_folder)
@@ -133,7 +133,7 @@ export def get-file [
 
 # Delete a key from the KV store
 export def del [
-    key: string@'nu-complete-key-names' = 'last'  # Specify the key to delete
+    key: string@'nu-complete-key-names' = 'last' # Specify the key to delete
 ] {
     # Remove the key and save the KV store
     load-kv | reject $key | save -f (kv-path)
@@ -151,19 +151,19 @@ export def reset [] {
 
 # Push a value to a list in the KV store
 export def push [
-    key: string                 # Specify the key to push to
-    value?: any                 # Provide the value to push (optional if used in a pipeline)
-    -p                          # Output the input value back to the pipeline
-    -u                          # Ensure uniqueness in the list
+    key: string # Specify the key to push to
+    value?: any # Provide the value to push (optional if used in a pipeline)
+    -p # Output the input value back to the pipeline
+    -u # Ensure uniqueness in the list
 ]: any -> any {
     let input = $in
     let value_to_push = if $value != null {
-            $value
-        } else if $input != null {
-            $input
-        } else {
-            error make { msg: "No value provided to push" }
-        }
+        $value
+    } else if $input != null {
+        $input
+    } else {
+        error make {msg: "No value provided to push"}
+    }
 
     let kv_store = load-kv
 
@@ -176,16 +176,16 @@ export def push [
         # Key exists; retrieve and update the list
         let stored_list = $kv_store | core_get $key
         if not ($stored_list | describe | str starts-with 'list') {
-            error make { msg: $"Key '($key)' is not associated with a list" }
+            error make {msg: $"Key '($key)' is not associated with a list"}
         }
 
         let updated_list = if $u {
-                # Ensure uniqueness
-                $stored_list | where {|x| $x != $value_to_push} | append $value_to_push
-            } else {
-                # Simply append the new value
-                $stored_list | append $value_to_push
-            }
+            # Ensure uniqueness
+            $stored_list | where {|x| $x != $value_to_push } | append $value_to_push
+        } else {
+            # Simply append the new value
+            $stored_list | append $value_to_push
+        }
 
         # Update the KV store
         $kv_store | upsert $key $updated_list | save -f (kv-path)
@@ -210,11 +210,11 @@ export def push [
 # │ empty list │
 # ╰────────────╯
 export def "pop" [
-    key  # Key to get
+    key # Key to get
 ] {
     let stored = get $key
     let value = $stored
-        | if ($in | length) == 0 { return } else { last }
+    | if ($in | length) == 0 { return } else { last }
 
     if ($stored | length) > 0 { set $key ($stored | drop) }
 
@@ -226,7 +226,7 @@ def nu-complete-key-names [] {
     main
     | rename value description
     | {
-        completions : $in,
+        completions : $in
         options: {
             sort: false
         }

--- a/numd/kv/commands.nu
+++ b/numd/kv/commands.nu
@@ -43,7 +43,7 @@ export def --env init [
 ] {
     if $dir != null { $env.kv.path = $dir }
 
-    let $kv_file = kv-path
+    let kv_file = kv-path
 
     if $reset or not ($kv_file | path exists) {
         # Create the values folder and initialize an empty KV store
@@ -70,12 +70,12 @@ export def set [
     --return-to-stdout (-p)       # Output the input value back to the pipeline
     --extension (-e): string = '' # Specify the file extension for saving
 ]: any -> any {
-    let $input = $in # we store input here as it might be needed to return at the end of this command
-    let $value_to_store = if $value == null { $input } else { $value }
-    let $value_type = $value_to_store | describe
+    let input = $in # we store input here as it might be needed to return at the end of this command
+    let value_to_store = if $value == null { $input } else { $value }
+    let value_type = $value_to_store | describe
 
     # Determine the file extension based on the value type
-    let $file_extension = if $extension != '' {
+    let file_extension = if $extension != '' {
             $extension
         } else if $value_type =~ 'table|list|record|binary' {
             'msgpackz'
@@ -86,7 +86,7 @@ export def set [
         }
 
     # Generate a unique filename for the value
-    let $file_path = kv-path --values_folder
+    let file_path = kv-path --values_folder
         | path join $"($key)_(date-now).($file_extension)"
 
     # Save the value to the file
@@ -156,8 +156,8 @@ export def push [
     -p                          # Output the input value back to the pipeline
     -u                          # Ensure uniqueness in the list
 ]: any -> any {
-    let $input = $in
-    let $value_to_push = if $value != null {
+    let input = $in
+    let value_to_push = if $value != null {
             $value
         } else if $input != null {
             $input
@@ -165,7 +165,7 @@ export def push [
             error make { msg: "No value provided to push" }
         }
 
-    let $kv_store = load-kv
+    let kv_store = load-kv
 
     if not ($key in $kv_store) {
         # Key does not exist; create a new list with the value
@@ -174,12 +174,12 @@ export def push [
         | save -f (kv-path)
     } else {
         # Key exists; retrieve and update the list
-        let $stored_list = $kv_store | core_get $key
+        let stored_list = $kv_store | core_get $key
         if not ($stored_list | describe | str starts-with 'list') {
             error make { msg: $"Key '($key)' is not associated with a list" }
         }
 
-        let $updated_list = if $u {
+        let updated_list = if $u {
                 # Ensure uniqueness
                 $stored_list | where {|x| $x != $value_to_push} | append $value_to_push
             } else {
@@ -212,8 +212,8 @@ export def push [
 export def "pop" [
     key  # Key to get
 ] {
-    let $stored = get $key
-    let $value = $stored
+    let stored = get $key
+    let value = $stored
         | if ($in | length) == 0 { return } else { last }
 
     if ($stored | length) > 0 { set $key ($stored | drop) }

--- a/numd/kv/mod.nu
+++ b/numd/kv/mod.nu
@@ -10,4 +10,4 @@ export use commands.nu [
     init
 ]
 
-export def main [] {ls}
+export def main [] { ls }

--- a/numd/kv/mod.nu
+++ b/numd/kv/mod.nu
@@ -1,0 +1,13 @@
+export use commands.nu [
+    ls,
+    set,
+    get,
+    get-file,
+    del,
+    reset,
+    push,
+    pop,
+    init
+]
+
+export def main [] {ls}

--- a/numd/nu-utils/cprint.nu
+++ b/numd/nu-utils/cprint.nu
@@ -17,7 +17,7 @@ export def main [
     --indent (-i): int = 0
     --err_msg                       # produce a record with an error message
 ] {
-    let $width_safe = (
+    let width_safe = (
         term size
         | get columns
         | [$in $width] | math min
@@ -44,14 +44,14 @@ export def main [
     }
 
     def frameit [] {
-        let $text = $in;
-        let $width_frame = (
+        let text = $in;
+        let width_frame = (
             $width_safe
             | ($in // ($frame | str length))
             | [$in 1] | math max
         )
 
-        let $frame_line = (
+        let frame_line = (
             ' '
             | fill -a r -w $width_frame -c $frame
             | $'(ansi $frame_color)($in)(ansi reset)'

--- a/numd/nu-utils/cprint.nu
+++ b/numd/nu-utils/cprint.nu
@@ -8,20 +8,20 @@ export def main [
     --color (-c): any = 'default'
     --highlight_color (-h): any = 'green_bold'
     --frame_color (-r): any = 'dark_gray'
-    --frame (-f): string = ''   # A symbol (or a string) to frame a text
-    --before (-b): int = 0      # A number of new lines before a text
-    --after (-a): int = 1       # A number of new lines after a text
-    --echo (-e)                 # Echo text string instead of printing
-    --keep_single_breaks        # Don't remove single line breaks
-    --width (-w): int = 80      # The width of text to format it
+    --frame (-f): string = '' # A symbol (or a string) to frame a text
+    --before (-b): int = 0 # A number of new lines before a text
+    --after (-a): int = 1 # A number of new lines after a text
+    --echo (-e) # Echo text string instead of printing
+    --keep_single_breaks # Don't remove single line breaks
+    --width (-w): int = 80 # The width of text to format it
     --indent (-i): int = 0
-    --err_msg                       # produce a record with an error message
+    --err_msg # produce a record with an error message
 ] {
     let width_safe = (
         term size
         | get columns
         | [$in $width] | math min
-        | [$in 40] | math max    # term size gives 0 in tests
+        | [$in 40] | math max # term size gives 0 in tests
     )
 
     def wrapit [] {
@@ -29,12 +29,12 @@ export def main [
         | str replace -r -a '(?m)^[\t ]+' ''
         | if $keep_single_breaks { } else {
             str replace -r -a '(\n[\t ]*(\n[\t ]*)+)' '⏎'
-            | str replace -r -a '\n' ' '        # remove single line breaks used for code formatting
+            | str replace -r -a '\n' ' ' # remove single line breaks used for code formatting
             | str replace -a '⏎' "\n\n"
         }
         | str replace -r -a '[\t ]+$' ''
         | str replace -r -a $"\(.{1,($width_safe - $indent)}\)\(\\s|$\)|\(.{1,($width_safe - $indent)}\)" "$1$3\n"
-        | str replace -r $'(char nl)$' ''       # trailing new line
+        | str replace -r $'(char nl)$' '' # trailing new line
         | str replace -r -a '(?m)^(.)' $'((char sp) | str repeat $indent)$1'
     }
 
@@ -73,7 +73,7 @@ export def main [
         | colorit
         | if $frame != '' {
             frameit
-        } else {}
+        } else { }
         | newlineit
         | if $err_msg {
             {msg: $in}

--- a/numd/nu-utils/parse.nu
+++ b/numd/nu-utils/parse.nu
@@ -6,5 +6,5 @@ export def main [
     open $file
     | lines
     | enumerate
-    | each {|i| $i.item | parse -r '^(?:(?<h>#+) (?<content>.*))?(?<c>```)?' | get 0 | merge $i}
+    | each {|i| $i.item | parse -r '^(?:(?<h>#+) (?<content>.*))?(?<c>```)?' | get 0 | merge $i }
 }

--- a/numd/nu-utils/str repeat.nu
+++ b/numd/nu-utils/str repeat.nu
@@ -1,6 +1,6 @@
 export def main [
     $n: int
 ]: string -> string {
-    let $text = $in
+    let text = $in
     seq 1 $n | each {$text} | str join
 }

--- a/numd/nu-utils/str repeat.nu
+++ b/numd/nu-utils/str repeat.nu
@@ -2,5 +2,5 @@ export def main [
     $n: int
 ]: string -> string {
     let text = $in
-    seq 1 $n | each {$text} | str join
+    seq 1 $n | each { $text } | str join
 }

--- a/nupm.nuon
+++ b/nupm.nuon
@@ -1,7 +1,7 @@
 {
   name: numd,
   type: module,
-  version: "0.1.17",
+  version: "0.1.18",
   description: "reproducible Nushell Markdown documents",
   license: Unlicense
 }

--- a/nupm.nuon
+++ b/nupm.nuon
@@ -1,7 +1,7 @@
 {
   name: numd,
   type: module,
-  version: "0.1.15",
+  version: "0.1.16",
   description: "reproducible Nushell Markdown documents",
   license: Unlicense
 }

--- a/nupm.nuon
+++ b/nupm.nuon
@@ -1,7 +1,7 @@
 {
   name: numd,
   type: module,
-  version: "0.1.16",
+  version: "0.1.17",
   description: "reproducible Nushell Markdown documents",
   license: Unlicense
 }

--- a/tools.nu
+++ b/tools.nu
@@ -1,7 +1,7 @@
 const numdinternals = ([numd commands.nu] | path join)
-use $numdinternals [modify-path]
+use $numdinternals [ modify-path ]
 
-def main [] {}
+def main [] { }
 
 def 'main testing' [] {
     use numd
@@ -21,18 +21,20 @@ def 'main testing' [] {
     | par-each --keep-order {|file|
         # Strip markdown
         let $strip_markdown_path = $file
-            | path parse
-            | get stem
-            | $in + '.nu'
-            | [z_examples 99_strip_markdown $in]
-            | path join
+        | path parse
+        | get stem
+        | $in + '.nu'
+        | [z_examples 99_strip_markdown $in]
+        | path join
 
         numd clear-outputs $file --strip-markdown --echo
         | save -f $strip_markdown_path
 
         # Run files with yaml config set
-        ( numd run $file --no-backup --save-intermed-script $'($file)_intermed.nu'
-            --config-path numd_config_example1.yaml )
+        (
+            numd run $file --no-backup --save-intermed-script $'($file)_intermed.nu'
+            --config-path numd_config_example1.yaml
+        )
     }
     # Run file with customized width of table
     | append (
@@ -54,7 +56,7 @@ def 'main testing' [] {
 
 def 'main release' [] {
     let $description = gh repo view --json description | from json | get description
-    let $tag = git tag | lines | sort -n | last | split row '.' | into int | update 2 {$in + 1} | str join '.'
+    let $tag = git tag | lines | sort -n | last | split row '.' | into int | update 2 { $in + 1 } | str join '.'
 
     open nupm.nuon
     | update description ($description | str replace 'numd - ' '')

--- a/tools.nu
+++ b/tools.nu
@@ -7,7 +7,7 @@ def 'main testing' [] {
     use numd
 
     # path join is used for windows compatability
-    let $path_simple_table = [z_examples 5_simple_nu_table simple_nu_table.md] | path join
+    let path_simple_table = [z_examples 5_simple_nu_table simple_nu_table.md] | path join
 
     # clear outputs from simple markdown
     ['z_examples' '1_simple_markdown' 'simple_markdown.md']
@@ -20,7 +20,7 @@ def 'main testing' [] {
     glob z_examples/*/*.md --exclude [*/*_with_no_output* */*_customized*]
     | par-each --keep-order {|file|
         # Strip markdown
-        let $strip_markdown_path = $file
+        let strip_markdown_path = $file
         | path parse
         | get stem
         | $in + '.nu'
@@ -55,8 +55,8 @@ def 'main testing' [] {
 }
 
 def 'main release' [] {
-    let $description = gh repo view --json description | from json | get description
-    let $tag = git tag | lines | sort -n | last | split row '.' | into int | update 2 { $in + 1 } | str join '.'
+    let description = gh repo view --json description | from json | get description
+    let tag = git tag | lines | sort -n | last | split row '.' | into int | update 2 { $in + 1 } | str join '.'
 
     open nupm.nuon
     | update description ($description | str replace 'numd - ' '')

--- a/tools.nu
+++ b/tools.nu
@@ -31,7 +31,7 @@ def 'main testing' [] {
         | save -f $strip_markdown_path
 
         # Run files with yaml config set
-        ( numd run $file --no-backup --intermed-script $'($file)_intermed.nu'
+        ( numd run $file --no-backup --save-intermed-script $'($file)_intermed.nu'
             --config-path numd_config_example1.yaml )
     }
     # Run file with customized width of table

--- a/tools.nu
+++ b/tools.nu
@@ -74,6 +74,8 @@ def 'main release' [] {
     # use nupm
     # nupm install --force --path .
 
+    git checkout main
+
     git add nupm.nuon
     git commit -m $'($tag) nupm version'
     git tag $tag

--- a/z_examples/2_numd_commands_explanations/numd_commands_explanations.md
+++ b/z_examples/2_numd_commands_explanations/numd_commands_explanations.md
@@ -41,7 +41,7 @@ Output:
 //  │              │                 │ ╰───────────────────────────────────────────────────────────────────────╯ │                │
 //  │            1 │ ```nu           │ ╭───────────────────╮                                                     │ execute        │
 //  │              │                 │ │ ```nu             │                                                     │                │
-//  │              │                 │ │ let $var1 = 'foo' │                                                     │                │
+//  │              │                 │ │ let var1 = 'foo' │                                                     │                │
 //  │              │                 │ │ ```               │                                                     │                │
 //  │              │                 │ ╰───────────────────╯                                                     │                │
 //  │            2 │ text            │ ╭──────────────╮                                                          │ print-as-it-is │
@@ -108,7 +108,7 @@ Output:
 //
 //  "```\n```output-numd" | print
 //
-//  let $var1 = 'foo'
+//  let var1 = 'foo'
 //
 //  "```" | print
 //
@@ -158,7 +158,7 @@ Output:
 ```
 //  #code-block-marker-open-1
 //  ```nu
-//  let $var1 = 'foo'
+//  let var1 = 'foo'
 //  ```
 //  ```output-numd
 //  ```
@@ -196,7 +196,7 @@ Output:
 ```
 //  #code-block-marker-open-1
 //  ```nu
-//  let $var1 = 'foo'
+//  let var1 = 'foo'
 //  ```
 //  #code-block-marker-open-3
 //  ```nu


### PR DESCRIPTION
- **0.1.16 nupm version**
- **0.1.17 nupm version**
- **add `git checkout main`**
- **0.1.18 nupm version**
- **use long flags**
- **add kv for catching data structures for tests**
- **add kv-catch**
- **use kv-catch**
- **move kv-catch to the end**
- **add example**
- **add signature**
- **add path-further to kv**
- **rename flag**
- **add piping results in**
- **add kv-catch**
- **add signature**
- **remove argument with pipe-in**
- **add kv-catch**
- **format with topiary**
- **format with topiary**
- **get rid of $ in declarations**
- **change formatting**
- **remove about R**
- **format with topiary**
