### PR TITLE
Feat/run once

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ Blocks support fence options (e.g., ` ```nushell try, no-output `):
 - `try` / `t`: Wrap in try-catch
 - `new-instance` / `n`: Execute in separate Nushell instance
 - `separate-block` / `s`: Output results in separate code block instead of inline `# =>`
+- `run-once` / `1`: Execute code block once, then set to `no-run`
 
 ### Output Format Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Blocks support fence options (e.g., ` ```nushell try, no-output `):
 - `try` / `t`: Wrap in try-catch
 - `new-instance` / `n`: Execute in separate Nushell instance
 - `separate-block` / `s`: Output results in separate code block instead of inline `# =>`
-- `run-once` / `1`: Execute code block once, then set to `no-run`
+- `run-once`: Execute code block once, then set to `no-run`
 
 ### Output Format Conventions
 

--- a/numd/commands.nu
+++ b/numd/commands.nu
@@ -256,7 +256,7 @@ export def decorate-original-code-blocks [
     | insert code {|i|
         $i.line
         | process-code-block-content ($i.row_type | extract-fence-options)
-        | generate-block-markers $i.block_index ($i.row_type | str replace 'run-once' 'no-run')
+        | generate-block-markers $i.block_index ($i.row_type | str replace 'run-once' 'no-run' | str replace -r '\b1\b' 'no-run')
     }
 }
 

--- a/numd/commands.nu
+++ b/numd/commands.nu
@@ -256,7 +256,7 @@ export def decorate-original-code-blocks [
     | insert code {|i|
         $i.line
         | process-code-block-content ($i.row_type | extract-fence-options)
-        | generate-block-markers $i.block_index $i.row_type
+        | generate-block-markers $i.block_index ($i.row_type | str replace 'run-once' 'no-run')
     }
 }
 
@@ -422,6 +422,7 @@ const fence_options = [
     [t try "execute block inside `try {}` for error handling"]
     [n new-instance "execute block in new Nushell instance (useful with `try` block)"]
     [s separate-block "output results in a separate code block instead of inline `# =>`"]
+    [1 run-once "execute code block once, then set to no-run"]
 ]
 
 # List fence options for execution and output customization.

--- a/numd/commands.nu
+++ b/numd/commands.nu
@@ -649,7 +649,7 @@ export def generate-block-markers [
 }
 
 # Parse options from a code fence and return them as a list.
-@example "parse fence options with short forms" { '```nu no-run, t' | extract-fence-options } --result [no-run, try]
+@example "parse fence options with short forms" { '```nu no-run, t' | extract-fence-options } --result [no-run try]
 export def extract-fence-options []: string -> list<string> {
     str replace -r '```nu(shell)?\s*' ''
     | split row ','

--- a/numd/commands.nu
+++ b/numd/commands.nu
@@ -256,7 +256,7 @@ export def decorate-original-code-blocks [
     | insert code {|i|
         $i.line
         | process-code-block-content ($i.row_type | extract-fence-options)
-        | generate-block-markers $i.block_index ($i.row_type | str replace 'run-once' 'no-run' | str replace -r '\b1\b' 'no-run')
+        | generate-block-markers $i.block_index ($i.row_type | str replace 'run-once' 'no-run')
     }
 }
 
@@ -422,7 +422,6 @@ const fence_options = [
     [t try "execute block inside `try {}` for error handling"]
     [n new-instance "execute block in new Nushell instance (useful with `try` block)"]
     [s separate-block "output results in a separate code block instead of inline `# =>`"]
-    [1 run-once "execute code block once, then set to no-run"]
 ]
 
 # List fence options for execution and output customization.

--- a/tests/test_commands.nu
+++ b/tests/test_commands.nu
@@ -170,11 +170,6 @@ def "convert-short-options expands n" [] {
 }
 
 @test
-def "convert-short-options expands 1" [] {
-    assert equal (convert-short-options "1") "run-once"
-}
-
-@test
 def "convert-short-options keeps long options unchanged" [] {
     assert equal (convert-short-options "no-output") "no-output"
     assert equal (convert-short-options "try") "try"

--- a/tests/test_commands.nu
+++ b/tests/test_commands.nu
@@ -83,6 +83,11 @@ def "classify-block-action returns print-as-it-is for no-run" [] {
 }
 
 @test
+def "classify-block-action returns execute for run-once" [] {
+    assert equal (classify-block-action "```nushell run-once") "execute"
+}
+
+@test
 def "classify-block-action returns delete for output-numd" [] {
     assert equal (classify-block-action "```output-numd") "delete"
 }
@@ -127,6 +132,13 @@ def "extract-fence-options expands short options" [] {
 }
 
 @test
+def "extract-fence-options parses run-once" [] {
+    let result = "```nu run-once" | extract-fence-options
+
+    assert equal $result ["run-once"]
+}
+
+@test
 def "extract-fence-options handles empty options" [] {
     let result = "```nushell" | extract-fence-options
 
@@ -155,6 +167,11 @@ def "convert-short-options expands t" [] {
 @test
 def "convert-short-options expands n" [] {
     assert equal (convert-short-options "n") "new-instance"
+}
+
+@test
+def "convert-short-options expands 1" [] {
+    assert equal (convert-short-options "1") "run-once"
 }
 
 @test

--- a/tests/test_commands.nu
+++ b/tests/test_commands.nu
@@ -88,6 +88,11 @@ def "classify-block-action returns execute for run-once" [] {
 }
 
 @test
+def "classify-block-action returns execute for run-once combined with try" [] {
+    assert equal (classify-block-action "```nushell run-once, try") "execute"
+}
+
+@test
 def "classify-block-action returns delete for output-numd" [] {
     assert equal (classify-block-action "```output-numd") "delete"
 }
@@ -136,6 +141,15 @@ def "extract-fence-options parses run-once" [] {
     let result = "```nu run-once" | extract-fence-options
 
     assert equal $result ["run-once"]
+}
+
+@test
+def "extract-fence-options parses run-once combined with try" [] {
+    let result = "```nu run-once, try" | extract-fence-options
+
+    assert equal ($result | length) 2
+    assert ("run-once" in $result)
+    assert ("try" in $result)
 }
 
 @test
@@ -385,6 +399,37 @@ def "generate-timestamp returns correct format" [] {
     # Format should be YYYYMMDD_HHMMSS (15 chars)
     assert equal ($result | str length) 15
     assert ($result =~ '^\d{8}_\d{6}$')
+}
+
+# =============================================================================
+# Tests for decorate-original-code-blocks (run-once rewriting)
+# =============================================================================
+
+@test
+def "decorate-original-code-blocks rewrites run-once to no-run" [] {
+    let blocks = "```nu run-once\necho hello\n```" | parse-markdown-to-blocks
+    let result = decorate-original-code-blocks $blocks
+
+    assert ($result.0.code =~ '```nu no-run')
+    assert ($result.0.code !~ 'run-once')
+}
+
+@test
+def "decorate-original-code-blocks rewrites run-once preserving other options" [] {
+    let blocks = "```nu run-once, try\necho hello\n```" | parse-markdown-to-blocks
+    let result = decorate-original-code-blocks $blocks
+
+    assert ($result.0.code =~ '```nu no-run, try')
+    assert ($result.0.code !~ 'run-once')
+}
+
+@test
+def "decorate-original-code-blocks leaves plain blocks unchanged" [] {
+    let blocks = "```nu\necho hello\n```" | parse-markdown-to-blocks
+    let result = decorate-original-code-blocks $blocks
+
+    assert ($result.0.code =~ '```nu')
+    assert ($result.0.code !~ 'no-run')
 }
 
 # =============================================================================

--- a/z_examples/6_edge_cases/run_once.md
+++ b/z_examples/6_edge_cases/run_once.md
@@ -1,0 +1,13 @@
+# run-once fence option
+
+After numd run, the run-once block below should become no-run with output preserved.
+
+```nu run-once
+2 + 2
+```
+
+This block uses run-once combined with no-output.
+
+```nu run-once, no-output
+3 + 3
+```


### PR DESCRIPTION
Summary

- Add run-once fence option that executes a code block once, then rewrites the fence to no-run so subsequent numd run calls skip it. Closes #71
- Works with combined options (e.g., ```nu run-once, try → ```nu no-run, try)
- Drop short-form 1 — it required a fragile \b1\b regex on the raw fence string, and run-once is inherently a one-time annotation where a short form adds no
convenience
- Docs: fix stale section title, heading structure, add extract-block-index and merge-markdown pipeline steps to commands explanations
- Fix @example list literal syntax in extract-fence-options

Test plan

- Unit tests for decorate-original-code-blocks verifying run-once → no-run rewriting (alone, combined with other options, plain blocks unchanged)
- Unit tests for classify-block-action and extract-fence-options with run-once combined options
- Integration test file z_examples/6_edge_cases/run_once.md — both run-once and run-once, no-output
- Verified second run produces no output (both blocks become no-run)
- All existing unit tests pass

