### PR TITLE
Fix run-once fence option validation and integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ numd run --help
 # => Run Nushell code blocks in a markdown file, output results back to the `.md`, and optionally to terminal
 # =>
 # => Usage:
-# =>   > run {flags} <file>
+# =>   > numd run {flags} <file>
 # =>
 # => Flags:
 # =>   -h, --help: Display the help message for this command
@@ -87,6 +87,7 @@ numd list-fence-options
 # => │ try            │ t     │ execute block inside `try {}` for error handling                 │
 # => │ new-instance   │ n     │ execute block in new Nushell instance (useful with `try` block)  │
 # => │ separate-block │ s     │ output results in a separate code block instead of inline `# =>` │
+# => │ run-once       │       │ execute code block once, then set to no-run                      │
 # => ╰──────long──────┴─short─┴───────────────────────────description────────────────────────────╯
 ```
 
@@ -143,7 +144,7 @@ numd clear-outputs --help
 # => and users typically clear outputs intentionally before committing clean source
 # =>
 # => Usage:
-# =>   > clear-outputs {flags} <file>
+# =>   > numd clear-outputs {flags} <file>
 # =>
 # => Flags:
 # =>   -h, --help: Display the help message for this command
@@ -172,7 +173,7 @@ numd capture start --help
 # => start capturing commands and their outputs into a file
 # =>
 # => Usage:
-# =>   > capture start {flags} (file)
+# =>   > numd capture start {flags} (file)
 # =>
 # => Flags:
 # =>   -h, --help: Display the help message for this command
@@ -195,7 +196,7 @@ numd capture stop --help
 # => stop capturing commands and their outputs
 # =>
 # => Usage:
-# =>   > capture stop
+# =>   > numd capture stop
 # =>
 # => Flags:
 # =>   -h, --help: Display the help message for this command
@@ -218,7 +219,7 @@ numd parse-md --help
 # => Parse markdown into semantic blocks
 # =>
 # => Usage:
-# =>   > parse-md (file)
+# =>   > numd parse-md (file)
 # =>
 # => Flags:
 # =>   -h, --help: Display the help message for this command
@@ -252,6 +253,8 @@ ls z_examples | sort-by name | reject modified size
 # => │ z_examples/999_numd_internals           │ dir  │
 # => │ z_examples/99_strip_markdown            │ dir  │
 # => │ z_examples/9_other                      │ dir  │
+# => │ z_examples/numd_config_example1.nu      │ file │
+# => │ z_examples/numd_config_example2.nu      │ file │
 # => ╰──────────────────name───────────────────┴─type─╯
 
 'hello world' | str length
@@ -261,7 +264,7 @@ ls z_examples | sort-by name | reject modified size
 # => 4
 
 git tag | lines | sort -n | last
-# => 0.3.0
+# => 0.4.0
 ```
 
 ## Real fight examples to try

--- a/README.md
+++ b/README.md
@@ -244,7 +244,6 @@ ls z_examples | sort-by name | reject modified size
 # => ╭──────────────────name───────────────────┬─type─╮
 # => │ z_examples/1_simple_markdown            │ dir  │
 # => │ z_examples/2_numd_commands_explanations │ dir  │
-# => │ z_examples/3_book_types_of_data         │ dir  │
 # => │ z_examples/4_book_working_with_lists    │ dir  │
 # => │ z_examples/5_simple_nu_table            │ dir  │
 # => │ z_examples/6_edge_cases                 │ dir  │

--- a/numd/commands.nu
+++ b/numd/commands.nu
@@ -422,6 +422,7 @@ const fence_options = [
     [t try "execute block inside `try {}` for error handling"]
     [n new-instance "execute block in new Nushell instance (useful with `try` block)"]
     [s separate-block "output results in a separate code block instead of inline `# =>`"]
+    ['' run-once "execute code block once, then set to no-run"]
 ]
 
 # List fence options for execution and output customization.

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -89,6 +89,7 @@ export def 'main test-integration' [
             */*_with_no_output*
             */*_customized*
             */8_parse_frontmatter
+            */run_once*
         ]
         | par-each --keep-order {|file|
             run-integration-test $file {
@@ -123,6 +124,15 @@ export def 'main test-integration' [
                 numd run $path_simple_table --echo --no-stats --eval (open -r ([z_examples numd_config_example2.nu] | path join))
                 | ansi strip
                 | save -f $target
+            }
+        )
+        # Run run-once test via --echo (file mutates by design, so we assert on output instead)
+        | append (
+            run-integration-test 'z_examples/6_edge_cases/run_once.md' {
+                let output = numd run z_examples/6_edge_cases/run_once.md --echo --no-stats
+                if ($output !~ '```nu no-run') or ($output =~ '```nu run-once') {
+                    error make {msg: 'run-once was not rewritten to no-run'}
+                }
             }
         )
         # Run readme

--- a/z_examples/99_strip_markdown/numd_commands_explanations.nu
+++ b/z_examples/99_strip_markdown/numd_commands_explanations.nu
@@ -39,8 +39,16 @@ $nu_res_stdout_lines
 
 
     # ```nu
-let $md_res = $nu_res_stdout_lines
-    | str join (char nl)
+let $nu_res_with_block_index = $nu_res_stdout_lines
+    | str replace -ar "\n{2,}```\n" "\n```\n"
+    | lines
+    | extract-block-index
+
+$nu_res_with_block_index | table -e --width 120
+
+
+    # ```nu
+let $md_res = merge-markdown $original_md_table $nu_res_with_block_index
     | clean-markdown
 
 $md_res

--- a/z_examples/99_strip_markdown/run_once.nu
+++ b/z_examples/99_strip_markdown/run_once.nu
@@ -1,0 +1,7 @@
+
+    # ```nu run-once
+2 + 2
+
+
+    # ```nu run-once, no-output
+3 + 3


### PR DESCRIPTION
## Summary

- Add `run-once` to the `fence_options` const table (with no short alias) so `convert-short-options` no longer warns about it being an unknown option
- Rework the `run_once.md` integration test to use `--echo` mode — since `run-once` mutates the source file by design (rewriting fences to `no-run`), running the test directly always produces a dirty diff. The test now asserts on the `--echo` output instead, keeping the fixture file stable and committable

## Test plan

- [x] `convert-short-options 'run-once'` returns `"run-once"` without warning
- [x] `list-fence-options` includes `run-once` with empty short column
- [x] `run_once.md` integration test passes without mutating the source file
- [x] Full test suite passes (all unit tests, integration `changed` only from environment-specific dynamic content)